### PR TITLE
[#28] 채팅방 컨트롤러를 리팩토링합니다.

### DIFF
--- a/src/main/java/site/bidderown/server/bounded_context/chat_room/controller/ChatRoomController.java
+++ b/src/main/java/site/bidderown/server/bounded_context/chat_room/controller/ChatRoomController.java
@@ -6,29 +6,45 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import site.bidderown.server.bounded_context.chat_room.controller.dto.ChatRoomDetail;
 import site.bidderown.server.bounded_context.chat_room.controller.dto.ChatRoomRequest;
+import site.bidderown.server.bounded_context.chat_room.controller.dto.ChatRoomResponse;
 import site.bidderown.server.bounded_context.chat_room.service.ChatRoomService;
 
+import java.util.List;
+
 @RequiredArgsConstructor
-@RequestMapping("/chat-room")
 @Controller
 public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
 
-    @GetMapping
-    public String handleChatRooms (
-            Model model,
-            @RequestBody ChatRoomRequest chatRoomRequest,
-            @RequestParam Boolean direct
-    ) {
-        if (direct) {
-            Long chatRoomId = chatRoomService.handleChatRoom(chatRoomRequest);
+    @GetMapping("/chat/list")
+    public String showChatRoomList (Model model, @RequestParam("id") Long chatRoomId) {
+        /**
+         *  채팅방 리스트 페이지로 이동
+         *  model에 담겨있는 채팅방에 자동
+         */
+        if (chatRoomId != null)
             model.addAttribute("chatRoomId", chatRoomId);
-        }
+
         return "/usr/chat/list";
     }
 
-    @GetMapping("/{chatRoomId}")
+    @GetMapping("/api/v1/chat/list")
+    @ResponseBody
+    public List<ChatRoomResponse> findChatRoomList(@RequestParam("memberId") Long memberId) {
+        return chatRoomService.findAllByMemberId(memberId);
+    }
+
+
+    @PostMapping("/api/v1/chat-room")
+    public String handleChatRoom(@RequestBody ChatRoomRequest chatRoomRequest){
+        /**
+         * 채팅방이 없다면 만들어주고 /chat/list?id=chatRoomId로 이동
+         */
+        return "redirect:/chat/list?id=" + chatRoomService.handleChatRoom(chatRoomRequest);
+    }
+
+    @GetMapping("/api/v1/chat/{chatRoomId}")
     @ResponseBody
     public ChatRoomDetail joinChat(@PathVariable Long chatRoomId){
         return chatRoomService.findChatRoomDetailById(chatRoomId);


### PR DESCRIPTION
- 기존의 채팅 리스트와 direct로 구분하던 API를 분리

- 채팅방 전체 조회
    - REST API
    - GET
    - /api/v1/chat/list


- 채팅방 전체 조회 및 특정 채팅방 바로가기
    -  VIEW
    - GET
    - /chat/list
    - /chat/list?id=
    - /usr/chat/list로 이동
    - /chat-room

- REST API
    - POST
    - /api/v1/chat-room
    - 채팅방이 있다면 그대로 chatRoomId를 반환
    - 없다면 만들어서 반환
    - 채팅방 바로가기로 리다이렉팅 /chat/list?id=