### PR TITLE
[#140] 입찰, 알림 Controller, RestController분리 재 요청

### DIFF
--- a/src/main/java/site/bidderown/server/bounded_context/bid/controller/BidApiController.java
+++ b/src/main/java/site/bidderown/server/bounded_context/bid/controller/BidApiController.java
@@ -1,0 +1,42 @@
+package site.bidderown.server.bounded_context.bid.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.*;
+import site.bidderown.server.bounded_context.bid.controller.dto.BidDetails;
+import site.bidderown.server.bounded_context.bid.controller.dto.BidRequest;
+import site.bidderown.server.bounded_context.bid.controller.dto.BidResponse;
+import site.bidderown.server.bounded_context.bid.controller.dto.BidResponses;
+import site.bidderown.server.bounded_context.bid.service.BidService;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class BidApiController {
+
+    private final BidService bidService;
+
+    @PostMapping("/api/v1/bid")
+    public Long registerBid(@RequestBody BidRequest bidRequest, @AuthenticationPrincipal User user){
+        return bidService.handleBid(bidRequest, user.getUsername());
+    }
+
+    @GetMapping("/api/v1/bid/list")
+    public BidResponses bidListApi(@RequestParam Long itemId){
+        BidDetails bidDetails = bidService.getBidStatistics(itemId);
+        List<BidResponse> bids = bidService.getBids(itemId);
+        return BidResponses.of(bidDetails, bids);
+    }
+
+    @GetMapping("/api/v1/bid-ids")
+    public List<Long> getBidItemIds(
+            @AuthenticationPrincipal User user
+    ) {
+        return bidService.getBidItemIds(user.getUsername());
+    }
+
+
+}
+

--- a/src/main/java/site/bidderown/server/bounded_context/bid/controller/BidController.java
+++ b/src/main/java/site/bidderown/server/bounded_context/bid/controller/BidController.java
@@ -21,18 +21,6 @@ public class BidController {
 
     private final BidService bidService;
 
-    @PostMapping("/bid")
-    public String registerBid(@RequestBody BidRequest bidRequest, @AuthenticationPrincipal User user){
-        bidService.handleBid(bidRequest, user.getUsername());
-        return "redirect:/bid/list?itemId=" + bidRequest.getItemId();
-    }
-
-    @PostMapping("/api/v1/bid")
-    @ResponseBody
-    public Long createBid(@RequestBody BidRequest bidRequest, @AuthenticationPrincipal User user){
-        return bidService.handleBid(bidRequest, user.getUsername());
-    }
-
     @GetMapping("/bid/list")
     @PreAuthorize("isAuthenticated()")
     public String bidList(@RequestParam Long itemId, Model model, @AuthenticationPrincipal User user){
@@ -40,19 +28,5 @@ public class BidController {
         return "usr/bid/list";
     }
 
-    @GetMapping("/api/v1/bid/list")
-    @ResponseBody
-    public BidResponses bidListApi(@RequestParam Long itemId){
-        BidDetails bidDetails = bidService.getBidStatistics(itemId);
-        List<BidResponse> bids = bidService.getBids(itemId);
-        return BidResponses.of(bidDetails, bids);
-    }
 
-    @GetMapping("/api/v1/bid-ids")
-    @ResponseBody
-    public List<Long> getBidItemIds(
-            @AuthenticationPrincipal User user
-    ) {
-        return bidService.getBidItemIds(user.getUsername());
-    }
 }

--- a/src/main/java/site/bidderown/server/bounded_context/chat_room/controller/ChatRoomApiController.java
+++ b/src/main/java/site/bidderown/server/bounded_context/chat_room/controller/ChatRoomApiController.java
@@ -22,7 +22,6 @@ import java.util.List;
 public class ChatRoomApiController {
 
     private final ChatRoomService chatRoomService;
-    private final MemberService memberService;
 
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/chat-room/list")
@@ -31,7 +30,6 @@ public class ChatRoomApiController {
     }
 
     @GetMapping("/chat-detail/{chatRoomId}")
-    @ResponseBody
     public ChatRoomDetail joinChat(@AuthenticationPrincipal User user, @PathVariable Long chatRoomId){
         return chatRoomService.getChatRoomDetail(chatRoomId, user.getUsername());
     }

--- a/src/main/java/site/bidderown/server/bounded_context/notification/controller/NotificationApiController.java
+++ b/src/main/java/site/bidderown/server/bounded_context/notification/controller/NotificationApiController.java
@@ -5,11 +5,10 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 import site.bidderown.server.bounded_context.notification.controller.dto.NotificationResponse;
 import site.bidderown.server.bounded_context.notification.entity.Notification;
 import site.bidderown.server.bounded_context.notification.service.NotificationService;
@@ -17,23 +16,28 @@ import site.bidderown.server.bounded_context.notification.service.NotificationSe
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
-public class NotificationController {
-
+public class NotificationApiController {
     private final NotificationService notificationService;
-
-    @GetMapping("/notifications")
+    @GetMapping("/api/v1/notifications")
     @PreAuthorize("isAuthenticated()")
-    public String notificationList(Model model) {
+    public List<NotificationResponse> notificationList() {
         String username = SecurityContextHolder.getContext().getAuthentication().getName();
         List<Notification> list = notificationService.getNotifications(username);
-        model.addAttribute("notifications",
-                list.stream().map(NotificationResponse::of)
-                        .collect(Collectors.toList())
-        );
 
-        return "usr/notification/list";
+        return list.stream().map(NotificationResponse::of).collect(Collectors.toList());
         // return dto 변환 코드 작성해야함
+    }
+
+    @GetMapping("/api/v1/notification-check")
+    public Boolean checkNotification(@AuthenticationPrincipal User user) {
+        if (user == null) return false;
+        return notificationService.checkNotRead(user.getUsername());
+    }
+
+    @PutMapping("/api/v1/notification/readAll")
+    public void readAllNotification() {
+        notificationService.readAll();
     }
 }

--- a/src/main/resources/templates/usr/bid/list.html
+++ b/src/main/resources/templates/usr/bid/list.html
@@ -168,10 +168,6 @@
                 }).catch(error => console.log(error));
 
                 axios.post('/api/v1/bid', {
-                    auth: {
-                        username: this.username,
-                        password: ''
-                    },
                     itemId: this.itemId,
                     itemPrice: this.bidPriceInput
                 }).then(response => {

--- a/src/main/resources/templates/usr/notification/list.html
+++ b/src/main/resources/templates/usr/notification/list.html
@@ -10,8 +10,8 @@
         <div class="text-3xl my-2 font-semibold">
             알림
         </div>
-        <div v-on:click="readAllNotification()" class="ml-auto" style="position: relative; top: 30px;">
-            <a id ="readAllNotification" class="text-l text-indigo-400 hover:bg-zinc-200"> 모든 알림 지우기</a>
+        <div class="ml-auto" style="position: relative; top: 30px;">
+            <a v-on:click="readAllNotification()" id ="readAllNotification" class="text-l text-indigo-400 hover:bg-zinc-200"> 모든 알림 지우기</a>
 
         </div>
     </div>
@@ -101,16 +101,16 @@
             notifications: [],
         },
         created() {
-            this.addData();
+            this.updateData();
             this.username = localStorage.getItem('username');
 
         },
         methods: {
-            addData() {
+            updateData() {
                 axios.get("/api/v1/notifications", {
                 }).then(response => {
                     console.log(response)
-
+                    this.notifications = [];
                     response.data.forEach(notification => {
                         this.notifications.push(
                             {
@@ -143,10 +143,9 @@
                 }
             },
             readAllNotification() {
-                const url = "/notifications";
-                axios.put('/notification/readAll',{
+                axios.put('/api/v1/notification/readAll',{
                 }).then(response => {
-                        window.location.href = url;
+                        this.updateData();
                     }).catch(error => {
                     console.log(error);
                 })


### PR DESCRIPTION
#140 

역할의 분리를 위해 view 흐름제어는 Controller에서 api요청은 RestController에서 담당하게 끔 리팩토링합니다.
알림 지우기가 실시간으로 반영되지 않았던 버그를 제거합니다.
Vue의 updateData 메서드가 가져온 알림목록을 추가하는 로직으로 작성되어있어 읽지 않은 알림 만을 가져와도 기존의 배열에 추가해주기 때문에 변화가 없었습니다. -> 가져올 때 기존의 배열을 초기화 해주는 방법으로 해결했습니다.