### PR TITLE
[#176] 알림 서비스 리팩토링 및 통합 테스트 작성

### DIFF
--- a/src/main/java/site/bidderown/server/bounded_context/notification/controller/dto/NewBidNotificationRequest.java
+++ b/src/main/java/site/bidderown/server/bounded_context/notification/controller/dto/NewBidNotificationRequest.java
@@ -1,13 +1,24 @@
 package site.bidderown.server.bounded_context.notification.controller.dto;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NewBidNotificationRequest {
     private Long itemId;
     private String memberName;
+
+    @Builder
+    private NewBidNotificationRequest(Long itemId, String memberName) {
+        this.itemId = itemId;
+        this.memberName = memberName;
+    }
+    public static NewBidNotificationRequest of(Long itemId, String memberName){
+        return NewBidNotificationRequest.builder()
+                .itemId(itemId)
+                .memberName(memberName)
+                .build();
+    }
+
 }

--- a/src/main/java/site/bidderown/server/bounded_context/notification/repository/NotificationRepository.java
+++ b/src/main/java/site/bidderown/server/bounded_context/notification/repository/NotificationRepository.java
@@ -14,4 +14,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     Boolean existsByReceiverAndReadDateIsNull(Member receiver);
 
     List<Notification> findByReceiverNameAndReadDateIsNull(String receiverName);
+
+    List<Notification> findAllByReadDateIsNull();
 }

--- a/src/test/java/site/bidderown/server/bounded_context/notification/service/NotificationServiceTest.java
+++ b/src/test/java/site/bidderown/server/bounded_context/notification/service/NotificationServiceTest.java
@@ -80,13 +80,15 @@ class NotificationServiceTest {
         /**
          * 알림을 등록한 뒤 알림의 DB에서 조회해 온 findNotification의 멤버값들을 각각 비교합니다.
          */
+        //given
         Member seller = createUser("member1");
         Item item = createItem(seller, "item1", "itemDescription", 10000);
 
+        //when
         Notification notification = notificationService.create(Notification.of(item, seller, NotificationType.BID));
-
         Notification findNotification = notificationRepository.findById(notification.getId()).orElse(null);
 
+        //then
         Assertions.assertEquals(notification.getItem() , findNotification.getItem());
         Assertions.assertEquals(notification.getReceiver() , findNotification.getReceiver());
         Assertions.assertEquals(notification.getNotificationType() , findNotification.getNotificationType());
@@ -98,9 +100,12 @@ class NotificationServiceTest {
         /**
          * 알림을 등록을 일괄 처리한 뒤 DB에서 조회해 온 알림 목록의 사이즈를 비교해봅니다.
          */
+        //given
         Member seller = createUser("member1");
         Item item = createItem(seller, "item1", "itemDescription", 10000);
 
+
+        //when
         List<Notification> notifications = new ArrayList<>();
 
         notifications.add(notificationService.create(Notification.of(item, seller, NotificationType.BID)));
@@ -110,6 +115,8 @@ class NotificationServiceTest {
         notificationService.create(notifications);
 
         List<Notification> findNotifications = notificationService.getNotifications(seller.getName());
+
+        //then
         assertThat(findNotifications.size()).isEqualTo(4);
 
     }
@@ -122,9 +129,11 @@ class NotificationServiceTest {
          *  모든 알림에서 자신의 알림의 수 만큼만 줄어들게 됩니다.
          *  모든 알림의 수 == 읽은 후 모든 알림의 수 - 읽은 양
          */
+        //given
         Member seller = createUser("member1");
         Item item = createItem(seller, "item1", "itemDescription", 10000);
 
+        //when
         List<Notification> notifications = new ArrayList<>();
 
         notifications.add(notificationService.create(Notification.of(item, seller, NotificationType.BID)));
@@ -138,6 +147,8 @@ class NotificationServiceTest {
 
         notificationService.readAll(seller.getName());
 
+
+        //then
         assertThat(notificationRepository.findAllByReadDateIsNull().size()).isEqualTo(before - readAmount);
     }
     @Test
@@ -148,14 +159,18 @@ class NotificationServiceTest {
          *  읽기 전 true
          *  읽은 후 false
          */
+        //given
         Member seller = createUser("member1");
         Item item = createItem(seller, "item1", "itemDescription", 10000);
 
         Notification notification = notificationService.create(Notification.of(item, seller, NotificationType.BID));
         assertThat(notificationService.checkNotRead(seller.getName())).isTrue();
 
+        //when
         notification.read();
 
+
+        //then
         assertThat(notificationService.checkNotRead(seller.getName())).isFalse();
     }
 

--- a/src/test/java/site/bidderown/server/bounded_context/notification/service/NotificationServiceTest.java
+++ b/src/test/java/site/bidderown/server/bounded_context/notification/service/NotificationServiceTest.java
@@ -9,20 +9,38 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
+import site.bidderown.server.bounded_context.bid.controller.dto.BidRequest;
+import site.bidderown.server.bounded_context.bid.entity.Bid;
+import site.bidderown.server.bounded_context.bid.service.BidService;
+import site.bidderown.server.bounded_context.comment.controller.dto.CommentRequest;
+import site.bidderown.server.bounded_context.comment.entity.Comment;
+import site.bidderown.server.bounded_context.comment.service.CommentService;
+import site.bidderown.server.bounded_context.image.service.ImageService;
+import site.bidderown.server.bounded_context.item.controller.dto.ItemRequest;
 import site.bidderown.server.bounded_context.item.entity.Item;
+import site.bidderown.server.bounded_context.item.repository.ItemRepository;
 import site.bidderown.server.bounded_context.item.service.ItemService;
 import site.bidderown.server.bounded_context.member.entity.Member;
 import site.bidderown.server.bounded_context.member.service.MemberService;
+import site.bidderown.server.bounded_context.notification.controller.dto.NewBidNotificationRequest;
 import site.bidderown.server.bounded_context.notification.entity.Notification;
+import site.bidderown.server.bounded_context.notification.entity.NotificationType;
 import site.bidderown.server.bounded_context.notification.repository.NotificationRepository;
 
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
 class NotificationServiceTest {
+
     @Autowired
     private NotificationService notificationService;
 
@@ -30,94 +48,199 @@ class NotificationServiceTest {
     private NotificationRepository notificationRepository;
 
     @Autowired
-    private ItemService itemService;
+    private ItemRepository itemRepository;
     @Autowired
     private MemberService memberService;
+    @Autowired
+    private ImageService imageService;
+    @Autowired
+    private BidService bidService;
 
-    @BeforeEach
-    public void beforeEach(){
-        notificationRepository.deleteAll();
+
+
+    Member createUser(String username){
+        return memberService.join(username,"1234");
+    }
+    Item createItem(Member member, String itemTitle, String itemDescription, Integer minimumPrice){
+        Item item = itemRepository.save(
+                Item.of(
+                    ItemRequest.builder()
+                    .title(itemTitle)
+                    .description(itemDescription)
+                    .period(3)
+                    .minimumPrice(minimumPrice)
+                    .build(), member));
+        imageService.create(item, List.of("image1.jpeg"));
+        return item;
     }
 
-
-
-    @Rollback(value = false)
     @Test
-    @DisplayName("입찰 알림 등록")
+    @DisplayName("알림 개별 등록")
     void t01(){
         /**
          * 알림을 등록한 뒤 알림의 DB에서 조회해 온 findNotification의 멤버값들을 각각 비교합니다.
          */
+        Member seller = createUser("member1");
+        Item item = createItem(seller, "item1", "itemDescription", 10000);
 
-        Item item = itemService.getItem(1L);
-        Member member = memberService.getMember(1L);
+        Notification notification = notificationService.create(Notification.of(item, seller, NotificationType.BID));
 
-//        Notification notification = notificationService.create(EventItemBidderNotification.of(item, member));
+        Notification findNotification = notificationRepository.findById(notification.getId()).orElse(null);
 
-//        Notification findNotification = notificationRepository.findById(notification.getId()).orElse(null);
-//
-//        Assertions.assertEquals(notification.getItem() , findNotification.getItem());
-//        Assertions.assertEquals(notification.getReceiver() , findNotification.getReceiver());
-//        Assertions.assertEquals(notification.getNotificationType() , findNotification.getNotificationType());
+        Assertions.assertEquals(notification.getItem() , findNotification.getItem());
+        Assertions.assertEquals(notification.getReceiver() , findNotification.getReceiver());
+        Assertions.assertEquals(notification.getNotificationType() , findNotification.getNotificationType());
     }
 
-    @Rollback(value = false)
     @Test
-    @DisplayName("알림 전체 조회")
+    @DisplayName("알림 등록 일괄처리")
     void t02(){
         /**
-         *  알림을 2개 등록한 뒤 모든 알림을 조회하여 개수를 비교합니다.
+         * 알림을 등록을 일괄 처리한 뒤 DB에서 조회해 온 알림 목록의 사이즈를 비교해봅니다.
          */
-        Item item1 = itemService.getItem(1L);
-        Item item2 = itemService.getItem(2L);
-        Member member = memberService.getMember(1L);
+        Member seller = createUser("member1");
+        Item item = createItem(seller, "item1", "itemDescription", 10000);
 
-//        Notification notification1 = notificationService.create(EventItemBidderNotification.of(item1, member));
-//        Notification notification2 = notificationService.create(EventItemBidderNotification.of(item2, member));
-        List<Notification> notifications = notificationService.getNotifications(member.getName());
+        List<Notification> notifications = new ArrayList<>();
 
-        Assertions.assertEquals(notifications.size(), 2);
+        notifications.add(notificationService.create(Notification.of(item, seller, NotificationType.BID)));
+        notifications.add(notificationService.create(Notification.of(item, seller, NotificationType.BID_END)));
+        notifications.add(notificationService.create(Notification.of(item, seller, NotificationType.SOLDOUT)));
+        notifications.add(notificationService.create(Notification.of(item, seller, NotificationType.COMMENT)));
+        notificationService.create(notifications);
+
+        List<Notification> findNotifications = notificationService.getNotifications(seller.getName());
+        assertThat(findNotifications.size()).isEqualTo(4);
+
     }
 
-    @Rollback(value = false)
     @Test
-    @DisplayName("알림 전체 읽음 처리")
+    @DisplayName("자신의 알림 모두 읽음처리")
     void t03(){
         /**
-         * 알림을 2개 등록한 뒤 모든 알림을 읽음처리합니다.
-         * 알림의 readDate가 notNull이라면 모든 알림을 읽었음을 의미합니다.
+         *  자신의 알림들만 모두 읽음처리 합니다.
+         *  모든 알림에서 자신의 알림의 수 만큼만 줄어들게 됩니다.
+         *  모든 알림의 수 == 읽은 후 모든 알림의 수 - 읽은 양
          */
-        Item item1 = itemService.getItem(1L);
-        Item item2 = itemService.getItem(2L);
-        Member member = memberService.getMember(1L);
+        Member seller = createUser("member1");
+        Item item = createItem(seller, "item1", "itemDescription", 10000);
 
-//        Notification notification1 = notificationService.create(EventItemBidderNotification.of(item1, member));
-//        Notification notification2 = notificationService.create(EventItemBidderNotification.of(item2, member));
+        List<Notification> notifications = new ArrayList<>();
 
-//        notificationService.readAll();
+        notifications.add(notificationService.create(Notification.of(item, seller, NotificationType.BID)));
+        notifications.add(notificationService.create(Notification.of(item, seller, NotificationType.BID_END)));
+        notifications.add(notificationService.create(Notification.of(item, seller, NotificationType.SOLDOUT)));
+        notifications.add(notificationService.create(Notification.of(item, seller, NotificationType.COMMENT)));
+        notificationService.create(notifications);
 
-//        Assertions.assertNotNull(notification1.getReadDate());
-//        Assertions.assertNotNull(notification2.getReadDate());
+        int before = notificationRepository.findAllByReadDateIsNull().size();
+        int readAmount = notificationService.getNotifications(seller.getName()).size();
+
+        notificationService.readAll(seller.getName());
+
+        assertThat(notificationRepository.findAllByReadDateIsNull().size()).isEqualTo(before - readAmount);
     }
-
-    @Rollback(value = false)
     @Test
-    @DisplayName("알림 확인 여부 체크")
+    @DisplayName("알림 읽음, 읽지않음 체크")
     void t04(){
         /**
-         * 알림을 2개 등록한 뒤 모든 알림을 읽음처리합니다.
-         * 알림의 readDate가 notNull이라면 모든 알림을 읽었음을 의미합니다.
+         *  member의 읽음 여부에 따라 true, false값을 리턴하는 checkNotRead의 동작 테스트를 진행합니다.
+         *  읽기 전 true
+         *  읽은 후 false
          */
-        Item item1 = itemService.getItem(1L);
-        Member member = memberService.getMember(1L);
+        Member seller = createUser("member1");
+        Item item = createItem(seller, "item1", "itemDescription", 10000);
 
-//        Notification notification1 = notificationService.create(EventItemBidderNotification.of(item1, member));
+        Notification notification = notificationService.create(Notification.of(item, seller, NotificationType.BID));
+        assertThat(notificationService.checkNotRead(seller.getName())).isTrue();
 
-        Assertions.assertEquals(notificationService.checkNotRead(member.getName()), true);
+        notification.read();
 
-//        notificationService.readAll();
-
-        Assertions.assertEquals(notificationService.checkNotRead(member.getName()), false);
+        assertThat(notificationService.checkNotRead(seller.getName())).isFalse();
     }
 
+    @Test
+    @DisplayName("입찰 등록 시 알림 발행")
+    void t05(){
+        /**
+         *
+         *  아이템에는 bidder1의 입찰이 등록 돼 있는 상황이다.
+         *  bidder2가 아이템에 입찰 등록을 했을 때 알림을 받는 사람은 판매자와 bidder1 뿐이다.
+         *  본인 제외 입찰자 + 판매자!
+         */
+
+        //given
+        Member seller = createUser("member1");
+        Item item = createItem(seller, "item1", "itemDescription", 10000);
+        Member bidder1 = createUser("member2");
+        Member bidder2 = createUser("member3");
+        bidService.handleBid(BidRequest.of(item.getId(), 10000), bidder1.getName());
+
+        //when
+        List<Notification> newBidNotifications = notificationService.createNewBidNotification(NewBidNotificationRequest.of(item.getId(), bidder2.getName()));
+
+        List<String> receivers = newBidNotifications.stream().map(notification -> notification.getReceiver().getName())
+                .collect(Collectors.toList());
+
+        //then
+
+        assertThat(newBidNotifications.get(0).getNotificationType()).isEqualTo(NotificationType.BID);
+        assertThat(newBidNotifications.get(0).getItem()).isEqualTo(item);
+        assertThat(seller.getName()).isIn(receivers);
+        assertThat(bidder1.getName()).isIn(receivers);
+        assertThat(bidder2.getName()).isNotIn(receivers);
+
+    }
+
+    @Test
+    @DisplayName("댓글 등록 시 알림 발행")
+    void t06(){
+        /**
+         *
+         *  판매자는 아이템에 댓글이 달렸을 때 알림을 받습니다.
+         */
+
+        //given
+        Member seller = createUser("member1");
+        Item item = createItem(seller, "item1", "itemDescription", 10000);
+        Member buyer = createUser("member2");
+
+        //when
+        Notification newCommentNotification = notificationService.createNewCommentNotification(item.getId());
+
+        //then
+        assertThat(newCommentNotification.getReceiver().getName()).isEqualTo("member1");
+        assertThat(newCommentNotification.getNotificationType()).isEqualTo(NotificationType.COMMENT);
+
+    }
+
+    @Test
+    @DisplayName("판매 완료 처리 시 알림 발행")
+    void t07(){
+        /**
+         *
+         *  판매자가 상품의 상태값을 판매 완료로 변경했을 때
+         *  모든 입찰자들은 알림을 받습니다.
+         */
+        //given
+        Member seller = createUser("member1");
+        Item item = createItem(seller, "item1", "itemDescription", 10000);
+        Member bidder1 = createUser("member2");
+        Member bidder2 = createUser("member3");
+        bidService.handleBid(BidRequest.of(item.getId(), 10000), bidder1.getName());
+        bidService.handleBid(BidRequest.of(item.getId(), 20000), bidder2.getName());
+
+        //when
+        List<Notification> soldOutNotifications = notificationService.createSoldOutNotification(item.getId());
+        List<String> receivers = soldOutNotifications.stream().map(notification -> notification.getReceiver().getName())
+                .collect(Collectors.toList());
+
+        //then
+        assertThat(soldOutNotifications.get(0).getNotificationType()).isEqualTo(NotificationType.SOLDOUT);
+        assertThat(soldOutNotifications.get(0).getItem()).isEqualTo(item);
+
+        assertThat(bidder1.getName()).isIn(receivers);
+        assertThat(bidder2.getName()).isIn(receivers);
+
+    }
 }


### PR DESCRIPTION
- 알림 생성하는 부분에 메시지 보내는 로직 한번에 묶었습니다.
- 알림 서비스 레포지토리 단의 통합 테스트를 작성했습니다.
- 트랜잭션이 테스트 범위 전체에 걸려 있다 보니 Bid생성 해줄 때 item의 bids도 값을 넣어줘야 할 것 같습니다. @JinseoPark-bd 
- 테스트 단에서 @Transactional을 사용할 때 확실하게 이해하고 사용해야 좋을 것 같습니다.
-> 문제점들이 조금씩 보이네요 시간 될 때 정리해서 공유해드리겠습니다.

