### PR TITLE
[#197] 상품 리스트 쿼리 튜닝

### DIFF
--- a/src/main/generated/site/bidderown/server/bounded_context/item/entity/QItem.java
+++ b/src/main/generated/site/bidderown/server/bounded_context/item/entity/QItem.java
@@ -22,11 +22,17 @@ public class QItem extends EntityPathBase<Item> {
 
     public static final QItem item = new QItem("item");
 
-    public final site.bidderown.server.base.base_entity.QBaseEntity _super = new site.bidderown.server.base.base_entity.QBaseEntity(this);
+    public final QItemBase _super = new QItemBase(this);
+
+    //inherited
+    public final NumberPath<Integer> bidCount = _super.bidCount;
 
     public final ListPath<site.bidderown.server.bounded_context.bid.entity.Bid, site.bidderown.server.bounded_context.bid.entity.QBid> bids = this.<site.bidderown.server.bounded_context.bid.entity.Bid, site.bidderown.server.bounded_context.bid.entity.QBid>createList("bids", site.bidderown.server.bounded_context.bid.entity.Bid.class, site.bidderown.server.bounded_context.bid.entity.QBid.class, PathInits.DIRECT2);
 
     public final ListPath<site.bidderown.server.bounded_context.chat_room.entity.ChatRoom, site.bidderown.server.bounded_context.chat_room.entity.QChatRoom> chatRooms = this.<site.bidderown.server.bounded_context.chat_room.entity.ChatRoom, site.bidderown.server.bounded_context.chat_room.entity.QChatRoom>createList("chatRooms", site.bidderown.server.bounded_context.chat_room.entity.ChatRoom.class, site.bidderown.server.bounded_context.chat_room.entity.QChatRoom.class, PathInits.DIRECT2);
+
+    //inherited
+    public final NumberPath<Integer> commentCount = _super.commentCount;
 
     public final ListPath<site.bidderown.server.bounded_context.comment.entity.Comment, site.bidderown.server.bounded_context.comment.entity.QComment> comments = this.<site.bidderown.server.bounded_context.comment.entity.Comment, site.bidderown.server.bounded_context.comment.entity.QComment>createList("comments", site.bidderown.server.bounded_context.comment.entity.Comment.class, site.bidderown.server.bounded_context.comment.entity.QComment.class, PathInits.DIRECT2);
 
@@ -51,6 +57,8 @@ public class QItem extends EntityPathBase<Item> {
     public final NumberPath<Integer> minimumPrice = createNumber("minimumPrice", Integer.class);
 
     public final ListPath<site.bidderown.server.bounded_context.notification.entity.Notification, site.bidderown.server.bounded_context.notification.entity.QNotification> notifications = this.<site.bidderown.server.bounded_context.notification.entity.Notification, site.bidderown.server.bounded_context.notification.entity.QNotification>createList("notifications", site.bidderown.server.bounded_context.notification.entity.Notification.class, site.bidderown.server.bounded_context.notification.entity.QNotification.class, PathInits.DIRECT2);
+
+    public final StringPath thumbnailImageFileName = createString("thumbnailImageFileName");
 
     public final StringPath title = createString("title");
 

--- a/src/main/generated/site/bidderown/server/bounded_context/item/entity/QItemBase.java
+++ b/src/main/generated/site/bidderown/server/bounded_context/item/entity/QItemBase.java
@@ -1,0 +1,50 @@
+package site.bidderown.server.bounded_context.item.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QItemBase is a Querydsl query type for ItemBase
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QItemBase extends EntityPathBase<ItemBase> {
+
+    private static final long serialVersionUID = 1747547197L;
+
+    public static final QItemBase itemBase = new QItemBase("itemBase");
+
+    public final site.bidderown.server.base.base_entity.QBaseEntity _super = new site.bidderown.server.base.base_entity.QBaseEntity(this);
+
+    public final NumberPath<Integer> bidCount = createNumber("bidCount", Integer.class);
+
+    public final NumberPath<Integer> commentCount = createNumber("commentCount", Integer.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    //inherited
+    public final NumberPath<Long> id = _super.id;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QItemBase(String variable) {
+        super(ItemBase.class, forVariable(variable));
+    }
+
+    public QItemBase(Path<? extends ItemBase> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QItemBase(PathMetadata metadata) {
+        super(ItemBase.class, metadata);
+    }
+
+}
+

--- a/src/main/java/site/bidderown/server/base/base_entity/BaseEntity.java
+++ b/src/main/java/site/bidderown/server/base/base_entity/BaseEntity.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
 @ToString
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public class BaseEntity {
+public abstract class BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/site/bidderown/server/base/data/NotProd.java
+++ b/src/main/java/site/bidderown/server/base/data/NotProd.java
@@ -195,35 +195,11 @@ public class NotProd {
 
             itemRepository.saveAll(items);
 
-            // 아이템 등록
-            List<BulkInsertItem> itemList = new ArrayList<>();
-            List<BulkInsertBid> bidList = new ArrayList<>();
-
-            for(long i = 1; i <= 100_000; i++) {
-                if (i % 2 == 0) {
-                    itemList.add(BulkInsertItem.builder()
-                            .memberId(member1.getId())
-                            .title("testTitle_" + i)
-                            .description("testDescription")
-                            .minimumPrice(10000)
-                            .build());
-                } else {
-                    itemList.add(BulkInsertItem.builder()
-                            .memberId(member2.getId())
-                            .title("testTitle_" + i)
-                            .description("testDescription")
-                            .minimumPrice(10000)
-                            .build());
-                }
-                bidList.add(BulkInsertBid.builder()
-                        .price(10000)
-                        .bidderId(kakaoMember1.getId())
-                        .itemId(i)
-                        .build());
+            for (int i = 0; i < 11; i++) {
+                imageService.create(items.get(i), List.of("image" + (i + 1) + ".jpeg"));
+                items.get(i).setThumbnailImageFileName("image" + (i + 1) + ".jpeg");
+                itemRepository.save(items.get(i));
             }
-
-            itemJdbcRepository.insertItemList(itemList);
-            bidJdbcRepository.insertBidList(bidList);
 
 
             bidService.create(BidRequest.of(items.get(0).getId(), 145_000), members.get(1).getName());
@@ -264,14 +240,35 @@ public class NotProd {
             bidService.create(BidRequest.of(items.get(9).getId(), 139_000), members.get(1).getName());
 
             for (int i = 0; i < 11; i++) {
-                imageService.create(items.get(i), List.of("image" + (i + 1) + ".jpeg"));
-
                 if (i == 10) {
                     commentService.create(CommentRequest.of("어디서 거래 가능하세요?"), items.get(i).getId(), members.get(0));
                 } else {
                     commentService.create(CommentRequest.of("어디서 거래 가능하세요?"), items.get(i).getId(), members.get(i + 1));
                 }
             }
+
+            // 아이템 등록
+            List<BulkInsertItem> itemList = new ArrayList<>();
+
+            for(long i = 1; i <= 100_000; i++) {
+                if (i % 2 == 0) {
+                    itemList.add(BulkInsertItem.builder()
+                            .memberId(member1.getId())
+                            .title("not_prod_title_" + i)
+                            .description("not_prod_description")
+                            .minimumPrice(10000)
+                            .build());
+                } else {
+                    itemList.add(BulkInsertItem.builder()
+                            .memberId(member2.getId())
+                            .title("not_prod_title_" + i)
+                            .description("not_prod_description")
+                            .minimumPrice(10000)
+                            .build());
+                }
+            }
+
+            itemJdbcRepository.insertItemList(itemList);
         };
     }
 }

--- a/src/main/java/site/bidderown/server/base/data/NotProd.java
+++ b/src/main/java/site/bidderown/server/base/data/NotProd.java
@@ -203,14 +203,14 @@ public class NotProd {
                 if (i % 2 == 0) {
                     itemList.add(BulkInsertItem.builder()
                             .memberId(member1.getId())
-                            .title("testTitle")
+                            .title("testTitle_" + i)
                             .description("testDescription")
                             .minimumPrice(10000)
                             .build());
                 } else {
                     itemList.add(BulkInsertItem.builder()
                             .memberId(member2.getId())
-                            .title("testTitle")
+                            .title("testTitle_" + i)
                             .description("testDescription")
                             .minimumPrice(10000)
                             .build());

--- a/src/main/java/site/bidderown/server/base/data/NotProd.java
+++ b/src/main/java/site/bidderown/server/base/data/NotProd.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import site.bidderown.server.bounded_context.bid.controller.dto.BidRequest;
-import site.bidderown.server.bounded_context.bid.controller.dto.BulkInsertBid;
 import site.bidderown.server.bounded_context.bid.repository.BidJdbcRepository;
 import site.bidderown.server.bounded_context.bid.service.BidService;
 import site.bidderown.server.bounded_context.comment.controller.dto.CommentRequest;
@@ -15,11 +14,9 @@ import site.bidderown.server.bounded_context.item.controller.dto.ItemRequest;
 import site.bidderown.server.bounded_context.item.entity.Item;
 import site.bidderown.server.bounded_context.item.repository.ItemJdbcRepository;
 import site.bidderown.server.bounded_context.item.repository.ItemRepository;
-import site.bidderown.server.bounded_context.item.repository.dto.BulkInsertItem;
 import site.bidderown.server.bounded_context.member.entity.Member;
 import site.bidderown.server.bounded_context.member.service.MemberService;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Profile({"dev", "test"})

--- a/src/main/java/site/bidderown/server/base/data/NotProd.java
+++ b/src/main/java/site/bidderown/server/base/data/NotProd.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import site.bidderown.server.bounded_context.bid.controller.dto.BidRequest;
+import site.bidderown.server.bounded_context.bid.controller.dto.BulkInsertBid;
 import site.bidderown.server.bounded_context.bid.repository.BidJdbcRepository;
 import site.bidderown.server.bounded_context.bid.service.BidService;
 import site.bidderown.server.bounded_context.comment.controller.dto.CommentRequest;
@@ -14,9 +15,11 @@ import site.bidderown.server.bounded_context.item.controller.dto.ItemRequest;
 import site.bidderown.server.bounded_context.item.entity.Item;
 import site.bidderown.server.bounded_context.item.repository.ItemJdbcRepository;
 import site.bidderown.server.bounded_context.item.repository.ItemRepository;
+import site.bidderown.server.bounded_context.item.repository.dto.BulkInsertItem;
 import site.bidderown.server.bounded_context.member.entity.Member;
 import site.bidderown.server.bounded_context.member.service.MemberService;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Profile({"dev", "test"})
@@ -191,6 +194,37 @@ public class NotProd {
             );
 
             itemRepository.saveAll(items);
+
+            // 아이템 등록
+            List<BulkInsertItem> itemList = new ArrayList<>();
+            List<BulkInsertBid> bidList = new ArrayList<>();
+
+            for(long i = 1; i <= 100_000; i++) {
+                if (i % 2 == 0) {
+                    itemList.add(BulkInsertItem.builder()
+                            .memberId(member1.getId())
+                            .title("testTitle")
+                            .description("testDescription")
+                            .minimumPrice(10000)
+                            .build());
+                } else {
+                    itemList.add(BulkInsertItem.builder()
+                            .memberId(member2.getId())
+                            .title("testTitle")
+                            .description("testDescription")
+                            .minimumPrice(10000)
+                            .build());
+                }
+                bidList.add(BulkInsertBid.builder()
+                        .price(10000)
+                        .bidderId(kakaoMember1.getId())
+                        .itemId(i)
+                        .build());
+            }
+
+            itemJdbcRepository.insertItemList(itemList);
+            bidJdbcRepository.insertBidList(bidList);
+
 
             bidService.create(BidRequest.of(items.get(0).getId(), 145_000), members.get(1).getName());
             bidService.create(BidRequest.of(items.get(0).getId(), 120_000), members.get(2).getName());

--- a/src/main/java/site/bidderown/server/base/data/NotProd.java
+++ b/src/main/java/site/bidderown/server/base/data/NotProd.java
@@ -246,29 +246,6 @@ public class NotProd {
                     commentService.create(CommentRequest.of("어디서 거래 가능하세요?"), items.get(i).getId(), members.get(i + 1));
                 }
             }
-
-            // 아이템 등록
-            List<BulkInsertItem> itemList = new ArrayList<>();
-
-            for(long i = 1; i <= 100_000; i++) {
-                if (i % 2 == 0) {
-                    itemList.add(BulkInsertItem.builder()
-                            .memberId(member1.getId())
-                            .title("not_prod_title_" + i)
-                            .description("not_prod_description")
-                            .minimumPrice(10000)
-                            .build());
-                } else {
-                    itemList.add(BulkInsertItem.builder()
-                            .memberId(member2.getId())
-                            .title("not_prod_title_" + i)
-                            .description("not_prod_description")
-                            .minimumPrice(10000)
-                            .build());
-                }
-            }
-
-            itemJdbcRepository.insertItemList(itemList);
         };
     }
 }

--- a/src/main/java/site/bidderown/server/batch/BatchScheduler.java
+++ b/src/main/java/site/bidderown/server/batch/BatchScheduler.java
@@ -22,7 +22,7 @@ public class BatchScheduler {
     private final CommandLineRunner initData;
 
 //    @Scheduled(fixedRate = 30000)
-    @Scheduled(cron = "0 0 * * * *")
+//    @Scheduled(cron = "0 0 * * * *")
     public void bidEndScheduler() throws Exception {
 
         JobParameters jobParameters = new JobParametersBuilder()

--- a/src/main/java/site/bidderown/server/batch/BatchScheduler.java
+++ b/src/main/java/site/bidderown/server/batch/BatchScheduler.java
@@ -22,7 +22,7 @@ public class BatchScheduler {
     private final CommandLineRunner initData;
 
 //    @Scheduled(fixedRate = 30000)
-//    @Scheduled(cron = "0 0 * * * *")
+    @Scheduled(cron = "0 0 * * * *")
     public void bidEndScheduler() throws Exception {
 
         JobParameters jobParameters = new JobParametersBuilder()

--- a/src/main/java/site/bidderown/server/bounded_context/comment/entity/Comment.java
+++ b/src/main/java/site/bidderown/server/bounded_context/comment/entity/Comment.java
@@ -35,8 +35,9 @@ public class Comment extends BaseEntity {
             Member writer
     ) {
         this.content = content;
-        this.item = item;
         this.writer = writer;
+        this.item = item;
+        this.item.getComments().add(this);
     }
 
     public static Comment of (
@@ -44,13 +45,11 @@ public class Comment extends BaseEntity {
         Item item,
         Member writer
     ) {
-        Comment comment = Comment.builder()
+        return Comment.builder()
                 .content(request.getContent())
                 .item(item)
                 .writer(writer)
                 .build();
-        item.getComments().add(comment);
-        return comment;
     }
 
     public void updateContent(String content){

--- a/src/main/java/site/bidderown/server/bounded_context/comment/service/CommentService.java
+++ b/src/main/java/site/bidderown/server/bounded_context/comment/service/CommentService.java
@@ -30,6 +30,7 @@ public class CommentService {
         Item item = itemService.getItem(itemId);
         Member writer = memberService.getMember(writerName);
         Comment comment = Comment.of(request, item, writer);
+        item.increaseCommentCount();
 
         return commentRepository.save(comment);
     }
@@ -38,7 +39,8 @@ public class CommentService {
     public Comment create(CommentRequest request, Long itemId, Member writer) {
         Item item = itemService.getItem(itemId);
         Comment comment = Comment.of(request, item, writer);
-
+        item.increaseCommentCount();
+        
         return commentRepository.save(comment);
     }
 
@@ -63,6 +65,7 @@ public class CommentService {
             throw new ForbiddenException("댓글 삭제 권한이 없습니다.");
         }
 
+        comment.getItem().decreaseCommentCount();
         commentRepository.delete(comment);
         return commentId;
     }

--- a/src/main/java/site/bidderown/server/bounded_context/item/controller/ItemApiController.java
+++ b/src/main/java/site/bidderown/server/bounded_context/item/controller/ItemApiController.java
@@ -36,7 +36,7 @@ public class ItemApiController {
         return itemService.getItems(sortCode, searchText, pageable);
     }
 
-    @GetMapping("/listv1")
+    @GetMapping("/list-v1")
     public List<ItemsResponse> getItemsV1(
             @RequestParam(name="s", defaultValue = "1") int sortCode,
             @RequestParam(name = "q", defaultValue = "") String searchText,
@@ -45,13 +45,23 @@ public class ItemApiController {
         return itemService.getItems_V1(sortCode, searchText, pageable);
     }
 
-    @GetMapping("/listv2")
+    @GetMapping("/list-v2")
     public List<ItemsResponse> getItemsV2(
             @RequestParam(name="s", defaultValue = "1") int sortCode,
             @RequestParam(name = "q", defaultValue = "") String searchText,
             Pageable pageable
     ) {
         return itemService.getItems_V2(sortCode, searchText, pageable);
+    }
+
+    @GetMapping("/list-no-offset")
+    public List<ItemsResponse> getItemsV2(
+            @RequestParam(name="s", defaultValue = "1") int sortCode,
+            @RequestParam(name = "q", defaultValue = "") String searchText,
+            @RequestParam(name = "id", required = false) Long lastItemId,
+            @RequestParam(name = "pageSize", defaultValue = "0") int pageSize
+    ) {
+        return itemService.getItems_no_offset(lastItemId, sortCode, searchText, pageSize);
     }
 
     @PostMapping(consumes = { MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE })

--- a/src/main/java/site/bidderown/server/bounded_context/item/controller/ItemApiController.java
+++ b/src/main/java/site/bidderown/server/bounded_context/item/controller/ItemApiController.java
@@ -33,7 +33,7 @@ public class ItemApiController {
             @RequestParam(name = "q", defaultValue = "") String searchText,
             Pageable pageable
     ) {
-        return itemService.getItems(sortCode, searchText, pageable);
+        return itemService.getItems_origin(sortCode, searchText, pageable);
     }
 
     @GetMapping("/list-no-dsl")
@@ -59,9 +59,9 @@ public class ItemApiController {
             @RequestParam(name="s", defaultValue = "1") int sortCode,
             @RequestParam(name = "q", defaultValue = "") String searchText,
             @RequestParam(name = "id", required = false) Long lastItemId,
-            @RequestParam(name = "pageSize", defaultValue = "0") int pageSize
+            Pageable pageable
     ) {
-        return itemService.getItems_dsl_no_offset(lastItemId, sortCode, searchText, pageSize);
+        return itemService.getItems(lastItemId, sortCode, searchText, pageable);
     }
 
     @PostMapping(consumes = { MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE })

--- a/src/main/java/site/bidderown/server/bounded_context/item/controller/ItemApiController.java
+++ b/src/main/java/site/bidderown/server/bounded_context/item/controller/ItemApiController.java
@@ -36,6 +36,24 @@ public class ItemApiController {
         return itemService.getItems(sortCode, searchText, pageable);
     }
 
+    @GetMapping("/listv1")
+    public List<ItemsResponse> getItemsV1(
+            @RequestParam(name="s", defaultValue = "1") int sortCode,
+            @RequestParam(name = "q", defaultValue = "") String searchText,
+            Pageable pageable
+    ) {
+        return itemService.getItems_V1(sortCode, searchText, pageable);
+    }
+
+    @GetMapping("/listv2")
+    public List<ItemsResponse> getItemsV2(
+            @RequestParam(name="s", defaultValue = "1") int sortCode,
+            @RequestParam(name = "q", defaultValue = "") String searchText,
+            Pageable pageable
+    ) {
+        return itemService.getItems_V2(sortCode, searchText, pageable);
+    }
+
     @PostMapping(consumes = { MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE })
     @PreAuthorize("isAuthenticated()")
     public String createItem(

--- a/src/main/java/site/bidderown/server/bounded_context/item/controller/ItemApiController.java
+++ b/src/main/java/site/bidderown/server/bounded_context/item/controller/ItemApiController.java
@@ -27,8 +27,20 @@ public class ItemApiController {
     private final ItemService itemService;
     private final MemberService memberService;
 
+    // No offset 적용하여 최신순 쿼리 성능 개선 (N + 1 문제 해결, 성능 최상)
     @GetMapping("/list")
     public List<ItemsResponse> getItems(
+            @RequestParam(name="s", defaultValue = "1") int sortCode,
+            @RequestParam(name = "q", defaultValue = "") String searchText,
+            @RequestParam(name = "id", required = false) Long lastItemId,
+            Pageable pageable
+    ) {
+        return itemService.getItems(lastItemId, sortCode, searchText, pageable);
+    }
+
+    //기존 코드 (N + 1 해결, 성능 최하)
+    @GetMapping("/list-origin")
+    public List<ItemsResponse> getItemsOrigin(
             @RequestParam(name="s", defaultValue = "1") int sortCode,
             @RequestParam(name = "q", defaultValue = "") String searchText,
             Pageable pageable
@@ -36,32 +48,14 @@ public class ItemApiController {
         return itemService.getItems_origin(sortCode, searchText, pageable);
     }
 
-    @GetMapping("/list-no-dsl")
-    public List<ItemsResponse> getItemsV1(
+    //JPA 사용 (N + 1 문제 발생, 성능 보통)
+    @GetMapping("/list-jpa")
+    public List<ItemsResponse> getItemsJpa(
             @RequestParam(name="s", defaultValue = "1") int sortCode,
             @RequestParam(name = "q", defaultValue = "") String searchText,
             Pageable pageable
     ) {
         return itemService.getItems_no_dsl(sortCode, searchText, pageable);
-    }
-
-    @GetMapping("/list-dsl-page")
-    public List<ItemsResponse> getItemsV2(
-            @RequestParam(name="s", defaultValue = "1") int sortCode,
-            @RequestParam(name = "q", defaultValue = "") String searchText,
-            Pageable pageable
-    ) {
-        return itemService.getItems_dsl_page(sortCode, searchText, pageable);
-    }
-
-    @GetMapping("/list-dsl-no-offset")
-    public List<ItemsResponse> getItemsV2(
-            @RequestParam(name="s", defaultValue = "1") int sortCode,
-            @RequestParam(name = "q", defaultValue = "") String searchText,
-            @RequestParam(name = "id", required = false) Long lastItemId,
-            Pageable pageable
-    ) {
-        return itemService.getItems(lastItemId, sortCode, searchText, pageable);
     }
 
     @PostMapping(consumes = { MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE })

--- a/src/main/java/site/bidderown/server/bounded_context/item/controller/ItemApiController.java
+++ b/src/main/java/site/bidderown/server/bounded_context/item/controller/ItemApiController.java
@@ -36,32 +36,32 @@ public class ItemApiController {
         return itemService.getItems(sortCode, searchText, pageable);
     }
 
-    @GetMapping("/list-v1")
+    @GetMapping("/list-no-dsl")
     public List<ItemsResponse> getItemsV1(
             @RequestParam(name="s", defaultValue = "1") int sortCode,
             @RequestParam(name = "q", defaultValue = "") String searchText,
             Pageable pageable
     ) {
-        return itemService.getItems_V1(sortCode, searchText, pageable);
+        return itemService.getItems_no_dsl(sortCode, searchText, pageable);
     }
 
-    @GetMapping("/list-v2")
+    @GetMapping("/list-dsl-page")
     public List<ItemsResponse> getItemsV2(
             @RequestParam(name="s", defaultValue = "1") int sortCode,
             @RequestParam(name = "q", defaultValue = "") String searchText,
             Pageable pageable
     ) {
-        return itemService.getItems_V2(sortCode, searchText, pageable);
+        return itemService.getItems_dsl_page(sortCode, searchText, pageable);
     }
 
-    @GetMapping("/list-no-offset")
+    @GetMapping("/list-dsl-no-offset")
     public List<ItemsResponse> getItemsV2(
             @RequestParam(name="s", defaultValue = "1") int sortCode,
             @RequestParam(name = "q", defaultValue = "") String searchText,
             @RequestParam(name = "id", required = false) Long lastItemId,
             @RequestParam(name = "pageSize", defaultValue = "0") int pageSize
     ) {
-        return itemService.getItems_no_offset(lastItemId, sortCode, searchText, pageSize);
+        return itemService.getItems_dsl_no_offset(lastItemId, sortCode, searchText, pageSize);
     }
 
     @PostMapping(consumes = { MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE })

--- a/src/main/java/site/bidderown/server/bounded_context/item/controller/dto/ItemDetailResponse.java
+++ b/src/main/java/site/bidderown/server/bounded_context/item/controller/dto/ItemDetailResponse.java
@@ -65,7 +65,7 @@ public class ItemDetailResponse {
                 .expireAt(item.getExpireAt())
                 .minPrice(minPrice)
                 .maxPrice(maxPrice)
-                .thumbnailImageName(item.getImages().get(0).getFileName())
+                .thumbnailImageName(item.getThumbnailImageFileName())
                 .bidCount(item.getBids().size())
                 .itemStatus(item.getItemStatus())
                 .build();

--- a/src/main/java/site/bidderown/server/bounded_context/item/controller/dto/ItemsResponse.java
+++ b/src/main/java/site/bidderown/server/bounded_context/item/controller/dto/ItemsResponse.java
@@ -45,50 +45,6 @@ public class ItemsResponse {
         this.expireAt = expireAt;
     }
 
-    @Builder
-    public ItemsResponse(
-            Long id,
-            String title,
-            int minimumPrice,
-            Integer commentsCount,
-            Integer bidCount,
-            String thumbnailImageName,
-            ItemStatus itemStatus,
-            LocalDateTime expireAt
-    ) {
-        this.id = id;
-        this.title = title;
-        this.minimumPrice = minimumPrice;
-        this.commentsCount = commentsCount;
-        this.bidCount = bidCount;
-        this.thumbnailImageName = thumbnailImageName;
-        this.itemStatus = itemStatus;
-        this.expireAt = expireAt;
-    }
-
-    @Builder
-    public ItemsResponse(
-            Long id,
-            String title,
-            int minimumPrice,
-            Integer maxPrice,
-            Integer minPrice,
-            Integer commentsCount,
-            Integer bidCount,
-            ItemStatus itemStatus,
-            LocalDateTime expireAt
-    ) {
-        this.id = id;
-        this.title = title;
-        this.minimumPrice = minimumPrice;
-        this.maxPrice = maxPrice;
-        this.minPrice = minPrice;
-        this.commentsCount = commentsCount;
-        this.bidCount = bidCount;
-        this.itemStatus = itemStatus;
-        this.expireAt = expireAt;
-    }
-
     public static ItemsResponse of(Item item, Integer minPrice, Integer maxPrice) {
         return ItemsResponse.builder()
                 .id(item.getId())
@@ -97,39 +53,9 @@ public class ItemsResponse {
                 .expireAt(item.getExpireAt())
                 .minPrice(minPrice)
                 .maxPrice(maxPrice)
-                .commentsCount(item.getComments().size())
-                .bidCount(item.getBids().size())
+                .commentsCount(item.getCommentCount())
+                .bidCount(item.getBidCount())
                 .thumbnailImageName(item.getThumbnailImage())
-                .itemStatus(item.getItemStatus())
-                .build();
-    }
-
-    public static ItemsResponse of(Item item, Integer bidCount, Integer commentsCount, Integer minPrice, Integer maxPrice) {
-        return ItemsResponse.builder()
-                .id(item.getId())
-                .title(item.getTitle())
-                .minimumPrice(item.getMinimumPrice())
-                .expireAt(item.getExpireAt())
-                .minPrice(minPrice)
-                .maxPrice(maxPrice)
-                .commentsCount(commentsCount)
-                .bidCount(bidCount)
-                .thumbnailImageName(item.getThumbnailImage())
-                .itemStatus(item.getItemStatus())
-                .build();
-    }
-
-    public static ItemsResponse of(Item item, Integer bidCount, Integer commentsCount, Integer minPrice, Integer maxPrice, String thumbnailImageName) {
-        return ItemsResponse.builder()
-                .id(item.getId())
-                .title(item.getTitle())
-                .minimumPrice(item.getMinimumPrice())
-                .expireAt(item.getExpireAt())
-                .minPrice(minPrice)
-                .maxPrice(maxPrice)
-                .commentsCount(commentsCount)
-                .bidCount(bidCount)
-                .thumbnailImageName(thumbnailImageName)
                 .itemStatus(item.getItemStatus())
                 .build();
     }

--- a/src/main/java/site/bidderown/server/bounded_context/item/controller/dto/ItemsResponse.java
+++ b/src/main/java/site/bidderown/server/bounded_context/item/controller/dto/ItemsResponse.java
@@ -1,15 +1,12 @@
 package site.bidderown.server.bounded_context.item.controller.dto;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import site.bidderown.server.bounded_context.item.entity.Item;
 import site.bidderown.server.bounded_context.item.entity.ItemStatus;
 
 import java.time.LocalDateTime;
 
-@Getter
+@Getter @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ItemsResponse {
     private Long id;
@@ -59,6 +56,36 @@ public class ItemsResponse {
                 .commentsCount(item.getComments().size())
                 .bidCount(item.getBids().size())
                 .thumbnailImageName(item.getThumbnailImage())
+                .itemStatus(item.getItemStatus())
+                .build();
+    }
+
+    public static ItemsResponse of(Item item, Integer bidCount, Integer commentsCount, Integer minPrice, Integer maxPrice) {
+        return ItemsResponse.builder()
+                .id(item.getId())
+                .title(item.getTitle())
+                .minimumPrice(item.getMinimumPrice())
+                .expireAt(item.getExpireAt())
+                .minPrice(minPrice)
+                .maxPrice(maxPrice)
+                .commentsCount(commentsCount)
+                .bidCount(bidCount)
+                .thumbnailImageName(item.getThumbnailImage())
+                .itemStatus(item.getItemStatus())
+                .build();
+    }
+
+    public static ItemsResponse of(Item item, Integer bidCount, Integer commentsCount, Integer minPrice, Integer maxPrice, String thumbnailImageName) {
+        return ItemsResponse.builder()
+                .id(item.getId())
+                .title(item.getTitle())
+                .minimumPrice(item.getMinimumPrice())
+                .expireAt(item.getExpireAt())
+                .minPrice(minPrice)
+                .maxPrice(maxPrice)
+                .commentsCount(commentsCount)
+                .bidCount(bidCount)
+                .thumbnailImageName(thumbnailImageName)
                 .itemStatus(item.getItemStatus())
                 .build();
     }

--- a/src/main/java/site/bidderown/server/bounded_context/item/controller/dto/ItemsResponse.java
+++ b/src/main/java/site/bidderown/server/bounded_context/item/controller/dto/ItemsResponse.java
@@ -45,6 +45,50 @@ public class ItemsResponse {
         this.expireAt = expireAt;
     }
 
+    @Builder
+    public ItemsResponse(
+            Long id,
+            String title,
+            int minimumPrice,
+            Integer commentsCount,
+            Integer bidCount,
+            String thumbnailImageName,
+            ItemStatus itemStatus,
+            LocalDateTime expireAt
+    ) {
+        this.id = id;
+        this.title = title;
+        this.minimumPrice = minimumPrice;
+        this.commentsCount = commentsCount;
+        this.bidCount = bidCount;
+        this.thumbnailImageName = thumbnailImageName;
+        this.itemStatus = itemStatus;
+        this.expireAt = expireAt;
+    }
+
+    @Builder
+    public ItemsResponse(
+            Long id,
+            String title,
+            int minimumPrice,
+            Integer maxPrice,
+            Integer minPrice,
+            Integer commentsCount,
+            Integer bidCount,
+            ItemStatus itemStatus,
+            LocalDateTime expireAt
+    ) {
+        this.id = id;
+        this.title = title;
+        this.minimumPrice = minimumPrice;
+        this.maxPrice = maxPrice;
+        this.minPrice = minPrice;
+        this.commentsCount = commentsCount;
+        this.bidCount = bidCount;
+        this.itemStatus = itemStatus;
+        this.expireAt = expireAt;
+    }
+
     public static ItemsResponse of(Item item, Integer minPrice, Integer maxPrice) {
         return ItemsResponse.builder()
                 .id(item.getId())

--- a/src/main/java/site/bidderown/server/bounded_context/item/entity/Item.java
+++ b/src/main/java/site/bidderown/server/bounded_context/item/entity/Item.java
@@ -22,7 +22,7 @@ import java.util.List;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Item extends BaseEntity {
+public class Item extends ItemBase {
 
     @Column(length = 30)
     private String title;
@@ -60,6 +60,8 @@ public class Item extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private ItemStatus itemStatus;
+
+    private String thumbnailImageFileName;
 
     @Builder
     private Item(
@@ -118,6 +120,10 @@ public class Item extends BaseEntity {
 
     public void updateDeleted() {
         this.deleted = true;
+    }
+
+    public void setThumbnailImageFileName(String thumbnailImageFileName) {
+        this.thumbnailImageFileName = thumbnailImageFileName;
     }
 }
 

--- a/src/main/java/site/bidderown/server/bounded_context/item/entity/ItemBase.java
+++ b/src/main/java/site/bidderown/server/bounded_context/item/entity/ItemBase.java
@@ -1,0 +1,31 @@
+package site.bidderown.server.bounded_context.item.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.bidderown.server.base.base_entity.BaseEntity;
+
+import javax.persistence.MappedSuperclass;
+
+@Getter
+@NoArgsConstructor
+@MappedSuperclass
+public abstract class ItemBase extends BaseEntity {
+    private int bidCount;
+    private int commentCount;
+
+    public void increaseBidCount() {
+        this.bidCount++;
+    }
+
+    public void decreaseBidCount() {
+        this.bidCount--;
+    }
+
+    public void increaseCommentCount() {
+        this.commentCount++;
+    }
+
+    public void decreaseCommentCount() {
+        this.commentCount--;
+    }
+}

--- a/src/main/java/site/bidderown/server/bounded_context/item/repository/ItemCustomRepository.java
+++ b/src/main/java/site/bidderown/server/bounded_context/item/repository/ItemCustomRepository.java
@@ -64,8 +64,8 @@ public class ItemCustomRepository {
                                 item.minimumPrice,
                                 itemBidMaxPrice(),
                                 itemBidMinPrice(),
-                                item.comments.size(),
-                                item.bids.size(),
+                                item.commentCount,
+                                item.bidCount,
                                 image.fileName,
                                 item.itemStatus,
                                 item.expireAt
@@ -104,7 +104,7 @@ public class ItemCustomRepository {
                 .collect(Collectors.toList());
     }
 
-    public List<ItemsResponse> findItems_dsl_page(int sortCode, String searchText, Pageable pageable) {
+    public List<ItemsResponse> findItems_pagination(int sortCode, String searchText, Pageable pageable) {
         return queryFactory
                 .select(
                         Projections.constructor(
@@ -114,9 +114,9 @@ public class ItemCustomRepository {
                                 item.minimumPrice,
                                 itemBidMaxPrice(),
                                 itemBidMinPrice(),
-                                item.comments.size(),
-                                item.bids.size(),
-                                itemThumbnailImageFileName(),
+                                item.commentCount,
+                                item.bidCount,
+                                item.thumbnailImageFileName,
                                 item.itemStatus,
                                 item.expireAt
                         )
@@ -132,7 +132,7 @@ public class ItemCustomRepository {
                 .fetch();
     }
 
-    public List<ItemsResponse> findItems_dsl_no_Offset(Long lastItemId, int sortCode, String searchText, int pageSize) {
+    public List<ItemsResponse> findItems_no_offset(Long lastItemId, int sortCode, String searchText, int pageSize) {
         return queryFactory
                 .select(
                         Projections.constructor(
@@ -142,9 +142,9 @@ public class ItemCustomRepository {
                                 item.minimumPrice,
                                 itemBidMaxPrice(),
                                 itemBidMinPrice(),
-                                item.comments.size(),
-                                item.bids.size(),
-                                itemThumbnailImageFileName(),
+                                item.commentCount,
+                                item.bidCount,
+                                item.thumbnailImageFileName,
                                 item.itemStatus,
                                 item.expireAt
                         )
@@ -177,14 +177,12 @@ public class ItemCustomRepository {
                                 item.minimumPrice,
                                 itemBidMaxPrice(),
                                 itemBidMinPrice(),
-                                image.fileName,
-                                item.bids.size(),
+                                item.thumbnailImageFileName,
+                                item.bidCount,
                                 item.itemStatus,
                                 item.expireAt
                         ))
                 .from(item)
-                .leftJoin(item.images, image)
-                .on(image.id.eq(itemThumbnailImageMaxId()))
                 .where(item.id.eq(id), eqNotDeleted())
                 .fetchOne());
     }
@@ -248,7 +246,7 @@ public class ItemCustomRepository {
     private OrderSpecifier<?>[] orderBySortCode(int sortCode) {
         List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
         switch (sortCode) {
-            case 2 -> orderSpecifiers.add(item.bids.size().desc());
+            case 2 -> orderSpecifiers.add(item.bidCount.desc());
             case 3 -> orderSpecifiers.add(item.expireAt.asc());
         }
         orderSpecifiers.add(item.id.desc());

--- a/src/main/java/site/bidderown/server/bounded_context/item/repository/ItemCustomRepository.java
+++ b/src/main/java/site/bidderown/server/bounded_context/item/repository/ItemCustomRepository.java
@@ -1,6 +1,5 @@
 package site.bidderown.server.bounded_context.item.repository;
 
-import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
@@ -14,8 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import site.bidderown.server.base.util.TimeUtils;
-import site.bidderown.server.bounded_context.image.entity.Image;
-import site.bidderown.server.bounded_context.image.repository.ImageRepository;
 import site.bidderown.server.bounded_context.item.controller.dto.ItemDetailResponse;
 import site.bidderown.server.bounded_context.item.controller.dto.ItemsResponse;
 import site.bidderown.server.bounded_context.item.entity.Item;
@@ -23,7 +20,6 @@ import site.bidderown.server.bounded_context.item.entity.Item;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -91,7 +87,7 @@ public class ItemCustomRepository {
     /**
      * @description 성능 테스트를 위해 남겨둔 메서드입니다. findItems()를 사용하시면 됩니다.
      */
-    public List<ItemsResponse> findItems_v1(int sortCode, String searchText, Pageable pageable) {
+    public List<ItemsResponse> findItems_no_dsl(int sortCode, String searchText, Pageable pageable) {
         List<Item> items = queryFactory.selectFrom(item)
                 .where(eqToSearchText(searchText))
                 .orderBy(orderBySortCode(sortCode))
@@ -108,7 +104,7 @@ public class ItemCustomRepository {
                 .collect(Collectors.toList());
     }
 
-    public List<ItemsResponse> findItems_v2(int sortCode, String searchText, Pageable pageable) {
+    public List<ItemsResponse> findItems_dsl_page(int sortCode, String searchText, Pageable pageable) {
         return queryFactory
                 .select(
                         Projections.constructor(
@@ -136,7 +132,7 @@ public class ItemCustomRepository {
                 .fetch();
     }
 
-    public List<ItemsResponse> findItemsNoOffset(Long lastItemId, int sortCode, String searchText, int pageSize) {
+    public List<ItemsResponse> findItems_dsl_no_Offset(Long lastItemId, int sortCode, String searchText, int pageSize) {
         return queryFactory
                 .select(
                         Projections.constructor(

--- a/src/main/java/site/bidderown/server/bounded_context/item/repository/ItemJdbcRepository.java
+++ b/src/main/java/site/bidderown/server/bounded_context/item/repository/ItemJdbcRepository.java
@@ -20,7 +20,7 @@ public class ItemJdbcRepository {
 
 
     public void insertItemList(List<BulkInsertItem> itemList){
-        jdbcTemplate.batchUpdate("insert into item (title,created_at, updated_at, expire_at ,item_status, description , minimum_Price, member_id) values (?, ?, ?, ?, ?, ?, ?, ?)",
+        jdbcTemplate.batchUpdate("insert into item (title,created_at, updated_at, expire_at ,item_status, description , minimum_Price, member_id, bid_count, comment_count) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 new BatchPreparedStatementSetter() {
                     @Override
                     public void setValues(PreparedStatement ps, int i) throws SQLException {
@@ -32,6 +32,8 @@ public class ItemJdbcRepository {
                         ps.setString(6, itemList.get(i).getDescription());
                         ps.setLong(7, itemList.get(i).getMinimumPrice());
                         ps.setLong(8, itemList.get(i).getMemberId());
+                        ps.setLong(9, 0L);
+                        ps.setLong(10, 0L);
                     }
 
                     @Override

--- a/src/main/java/site/bidderown/server/bounded_context/item/service/ItemService.java
+++ b/src/main/java/site/bidderown/server/bounded_context/item/service/ItemService.java
@@ -36,7 +36,6 @@ public class ItemService {
         return _create(request, member);
     }
 
-
     public Item create(ItemRequest request, String memberString) {
         Member member = memberService.getMember(memberString);
         return _create(request, member);
@@ -83,6 +82,7 @@ public class ItemService {
         Item item = itemRepository.save(Item.of(request, member));
         List<String> fileNames = imageUtils.uploadMulti(request.getImages(), "item");
         imageService.create(item, fileNames);
+        item.setThumbnailImageFileName(fileNames.get(0));
         return item;
     }
 
@@ -94,14 +94,15 @@ public class ItemService {
     }
 
     public List<ItemsResponse> getItems_dsl_page(int sortCode, String searchText, Pageable pageable) {
-        return itemCustomRepository.findItems_dsl_page(sortCode, searchText, pageable);
+        return itemCustomRepository.findItems_pagination(sortCode, searchText, pageable);
     }
 
-    public List<ItemsResponse> getItems_dsl_no_offset(Long lastItemId, int sortCode, String searchText, int pageSize) {
-        return itemCustomRepository.findItems_dsl_no_Offset(lastItemId, sortCode, searchText, pageSize);
+    public List<ItemsResponse> getItems(Long lastItemId, int sortCode, String searchText, Pageable pageable) {
+        if (sortCode != 1) return itemCustomRepository.findItems_pagination(sortCode, searchText, pageable);
+        return itemCustomRepository.findItems_no_offset(lastItemId, sortCode, searchText, pageable.getPageSize());
     }
 
-    public List<ItemsResponse> getItems(int sortCode, String searchText, Pageable pageable) {
+    public List<ItemsResponse> getItems_origin(int sortCode, String searchText, Pageable pageable) {
         return itemCustomRepository.findItems(sortCode, searchText, pageable);
     }
 

--- a/src/main/java/site/bidderown/server/bounded_context/item/service/ItemService.java
+++ b/src/main/java/site/bidderown/server/bounded_context/item/service/ItemService.java
@@ -31,7 +31,6 @@ public class ItemService {
     private final MemberService memberService;
     private final ImageService imageService;
     private final ImageUtils imageUtils;
-    private final ApplicationEventPublisher publisher;
 
     public Item create(ItemRequest request, Long memberId) {
         Member member = memberService.getMember(memberId);
@@ -85,7 +84,6 @@ public class ItemService {
         Item item = itemRepository.save(Item.of(request, member));
         List<String> fileNames = imageUtils.uploadMulti(request.getImages(), "item");
         imageService.create(item, fileNames);
-
         return item;
     }
 
@@ -98,6 +96,10 @@ public class ItemService {
 
     public List<ItemsResponse> getItems_V2(int sortCode, String searchText, Pageable pageable) {
         return itemCustomRepository.findItems_v2(sortCode, searchText, pageable);
+    }
+
+    public List<ItemsResponse> getItems_no_offset(Long lastItemId, int sortCode, String searchText, int pageSize) {
+        return itemCustomRepository.findItemsNoOffset(lastItemId, sortCode, searchText, pageSize);
     }
 
     public List<ItemsResponse> getItems(int sortCode, String searchText, Pageable pageable) {

--- a/src/main/java/site/bidderown/server/bounded_context/item/service/ItemService.java
+++ b/src/main/java/site/bidderown/server/bounded_context/item/service/ItemService.java
@@ -96,9 +96,12 @@ public class ItemService {
         return itemCustomRepository.findItems_v1(sortCode, searchText, pageable);
     }
 
+    public List<ItemsResponse> getItems_V2(int sortCode, String searchText, Pageable pageable) {
+        return itemCustomRepository.findItems_v2(sortCode, searchText, pageable);
+    }
+
     public List<ItemsResponse> getItems(int sortCode, String searchText, Pageable pageable) {
-//        return itemCustomRepository.findItems(sortCode, searchText, pageable);
-        return itemCustomRepository.findItems_v1(sortCode, searchText, pageable);
+        return itemCustomRepository.findItems(sortCode, searchText, pageable);
     }
 
     public List<ItemSimpleResponse> getItems(String memberName) {

--- a/src/main/java/site/bidderown/server/bounded_context/item/service/ItemService.java
+++ b/src/main/java/site/bidderown/server/bounded_context/item/service/ItemService.java
@@ -1,7 +1,6 @@
 package site.bidderown.server.bounded_context.item.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -90,16 +89,16 @@ public class ItemService {
     /**
      * @description 성능 테스트를 위해 남겨둔 메서드입니다. getItems() 사용하시면 됩니다.
      */
-    public List<ItemsResponse> getItems_V1(int sortCode, String searchText, Pageable pageable) {
-        return itemCustomRepository.findItems_v1(sortCode, searchText, pageable);
+    public List<ItemsResponse> getItems_no_dsl(int sortCode, String searchText, Pageable pageable) {
+        return itemCustomRepository.findItems_no_dsl(sortCode, searchText, pageable);
     }
 
-    public List<ItemsResponse> getItems_V2(int sortCode, String searchText, Pageable pageable) {
-        return itemCustomRepository.findItems_v2(sortCode, searchText, pageable);
+    public List<ItemsResponse> getItems_dsl_page(int sortCode, String searchText, Pageable pageable) {
+        return itemCustomRepository.findItems_dsl_page(sortCode, searchText, pageable);
     }
 
-    public List<ItemsResponse> getItems_no_offset(Long lastItemId, int sortCode, String searchText, int pageSize) {
-        return itemCustomRepository.findItemsNoOffset(lastItemId, sortCode, searchText, pageSize);
+    public List<ItemsResponse> getItems_dsl_no_offset(Long lastItemId, int sortCode, String searchText, int pageSize) {
+        return itemCustomRepository.findItems_dsl_no_Offset(lastItemId, sortCode, searchText, pageSize);
     }
 
     public List<ItemsResponse> getItems(int sortCode, String searchText, Pageable pageable) {

--- a/src/main/java/site/bidderown/server/bounded_context/item/service/ItemService.java
+++ b/src/main/java/site/bidderown/server/bounded_context/item/service/ItemService.java
@@ -97,7 +97,8 @@ public class ItemService {
     }
 
     public List<ItemsResponse> getItems(int sortCode, String searchText, Pageable pageable) {
-        return itemCustomRepository.findItems(sortCode, searchText, pageable);
+//        return itemCustomRepository.findItems(sortCode, searchText, pageable);
+        return itemCustomRepository.findItems_v1(sortCode, searchText, pageable);
     }
 
     public List<ItemSimpleResponse> getItems(String memberName) {

--- a/src/main/java/site/bidderown/server/bounded_context/item/service/ItemService.java
+++ b/src/main/java/site/bidderown/server/bounded_context/item/service/ItemService.java
@@ -46,16 +46,6 @@ public class ItemService {
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 상품입니다.", id + ""));
     }
 
-    /**
-     * @description 성능 테스트를 위해 남겨 둔 메서드입니다. getItemDetail() 사용하시면 됩니다.
-     */
-    public ItemDetailResponse getItemDetail_V1(Long id) {
-        Item item = getItem(id);
-        Integer minPrice = itemCustomRepository.minItemPrice(id);
-        Integer maxPrice = itemCustomRepository.maxItemPrice(id);
-        return ItemDetailResponse.of(item, minPrice, maxPrice);
-    }
-
     public ItemDetailResponse getItemDetail(Long id) {
         return itemCustomRepository.findItemById(id)
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 상품입니다.", id + ""));
@@ -87,6 +77,18 @@ public class ItemService {
     }
 
     /**
+     * @param lastItemId 현재 상품리스트의 id 최소값
+     * @param sortCode 1 - 최신순, 2 - 인기순, 3 - 경매마감순
+     * @param searchText 검색어
+     * @param pageable 최신순 - pageSize만 이용, 나머지 - Pageable 이용
+     * @return List<ItemResponse>
+     */
+    public List<ItemsResponse> getItems(Long lastItemId, int sortCode, String searchText, Pageable pageable) {
+        if (sortCode != 1) return itemCustomRepository.findItems_pagination(sortCode, searchText, pageable);
+        return itemCustomRepository.findItems_no_offset(lastItemId, sortCode, searchText, pageable.getPageSize());
+    }
+
+    /**
      * @description 성능 테스트를 위해 남겨둔 메서드입니다. getItems() 사용하시면 됩니다.
      */
     public List<ItemsResponse> getItems_no_dsl(int sortCode, String searchText, Pageable pageable) {
@@ -95,11 +97,6 @@ public class ItemService {
 
     public List<ItemsResponse> getItems_dsl_page(int sortCode, String searchText, Pageable pageable) {
         return itemCustomRepository.findItems_pagination(sortCode, searchText, pageable);
-    }
-
-    public List<ItemsResponse> getItems(Long lastItemId, int sortCode, String searchText, Pageable pageable) {
-        if (sortCode != 1) return itemCustomRepository.findItems_pagination(sortCode, searchText, pageable);
-        return itemCustomRepository.findItems_no_offset(lastItemId, sortCode, searchText, pageable.getPageSize());
     }
 
     public List<ItemsResponse> getItems_origin(int sortCode, String searchText, Pageable pageable) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,6 +10,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
+#    properties:
+#      hibernate:
+#        format_sql: true
+#        show_sql: true
   security:
     oauth2:
       client:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,10 +10,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
-#    properties:
-#      hibernate:
-#        format_sql: true
-#        show_sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
   security:
     oauth2:
       client:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,10 +10,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
-    properties:
-      hibernate:
-        format_sql: true
-        show_sql: true
+#    properties:
+#      hibernate:
+#        format_sql: true
+#        show_sql: true
   security:
     oauth2:
       client:

--- a/src/main/resources/templates/usr/item/home.html
+++ b/src/main/resources/templates/usr/item/home.html
@@ -91,7 +91,7 @@
             page: 0,
             size: 9,
             searchText: '',
-            prefix: '/api/v1/item/list',
+            prefix: '/api/v1/item/list-no-offset',
         },
         created() {
             this.username = document.getElementById('username').value;
@@ -102,12 +102,7 @@
         },
         methods: {
             addData() {
-                axios.get(this.prefix + this.getQuery(), {
-                    params: {
-                        page: this.page,
-                        size: this.size
-                    }
-                }).then(response => {
+                axios.get(this.prefix + this.getQuery() + this.getLastItemId()).then(response => {
                     response.data.forEach(item => {
                         this.items.push(
                             {
@@ -178,6 +173,14 @@
                     }
                     query += 'q=' + this.searchText;
                 }
+                return query;
+            },
+            getLastItemId() {
+                let query = '';
+                if (this.items.length > 0) {
+                    query += "&id=" + this.items[this.items.length - 1].id;
+                }
+                query += "&pageSize=" + this.size;
                 return query;
             }
         }

--- a/src/main/resources/templates/usr/item/home.html
+++ b/src/main/resources/templates/usr/item/home.html
@@ -59,7 +59,7 @@
                         </span>
                         <span class="text-sm text-gray-600"  v-if="isPriceShow(item.minPrice) === false">최고가&nbsp₩&nbsp</span>
                     </div>
-                    <div class="text-sm text-gray-600" v-if="item.itemStatus === '경매중'">{{ item.expireAt }}</div>
+                    <div class="text-sm text-gray-600" v-if="item.itemStatus === 'BIDDING'">{{ item.expireAt }}</div>
                     <div v-else>&nbsp</div>
                 </div>
             </div>
@@ -91,7 +91,7 @@
             page: 0,
             size: 9,
             searchText: '',
-            prefix: '/api/v1/item/list-no-offset',
+            prefix: '/api/v1/item/list-dsl-no-offset',
         },
         created() {
             this.username = document.getElementById('username').value;
@@ -177,10 +177,10 @@
             },
             getLastItemId() {
                 let query = '';
-                if (this.items.length > 0) {
+                if (this.items.length > 0 && this.selected === '1') {
                     query += "&id=" + this.items[this.items.length - 1].id;
                 }
-                query += "&pageSize=" + this.size;
+                query += "&page=" + this.page + "&size=" + this.size;
                 return query;
             }
         }

--- a/src/main/resources/templates/usr/item/home.html
+++ b/src/main/resources/templates/usr/item/home.html
@@ -91,7 +91,7 @@
             page: 0,
             size: 9,
             searchText: '',
-            prefix: '/api/v1/item/list-dsl-no-offset',
+            prefix: '/api/v1/item/list',
         },
         created() {
             this.username = document.getElementById('username').value;

--- a/src/test/java/site/bidderown/server/bounded_context/item/service/ItemServiceTest.java
+++ b/src/test/java/site/bidderown/server/bounded_context/item/service/ItemServiceTest.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/site/bidderown/server/bounded_context/item/service/ItemServiceTest.java
+++ b/src/test/java/site/bidderown/server/bounded_context/item/service/ItemServiceTest.java
@@ -28,7 +28,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -60,7 +59,7 @@ public class ItemServiceTest {
     @Autowired
     private BidService bidService;
 
-    private final int PAGE_SIZE = 10;
+    private final int PAGE_SIZE = 9;
     private final int ITEM_SIZE = 5;
 
     @BeforeEach
@@ -91,7 +90,7 @@ public class ItemServiceTest {
         PageRequest pageRequest = PageRequest.of(0, PAGE_SIZE);
 
         //when
-        List<ItemsResponse> items = itemService.getItems(sortCode, searchText, pageRequest);
+        List<ItemsResponse> items = itemService.getItems(null, sortCode, searchText, pageRequest);
 
         //then
         assertThat(items.size()).isEqualTo(5);
@@ -109,7 +108,7 @@ public class ItemServiceTest {
         PageRequest pageRequest = PageRequest.of(0, PAGE_SIZE);
 
         //when
-        List<ItemsResponse> items = itemService.getItems(sortCode, searchText, pageRequest);
+        List<ItemsResponse> items = itemService.getItems(null, sortCode, searchText, pageRequest);
 
         //then
         assertThat(items.size()).isEqualTo(5);
@@ -127,7 +126,8 @@ public class ItemServiceTest {
         PageRequest pageRequest = PageRequest.of(0, PAGE_SIZE);
 
         //when
-        List<ItemsResponse> items = itemService.getItems(sortCode, searchText, pageRequest);
+//        List<ItemsResponse> items = itemService.getItems(sortCode, searchText, pageRequest);
+        List<ItemsResponse> items = itemService.getItems(null, sortCode, searchText, pageRequest);
 
         //then
         assertThat(items.size()).isEqualTo(5);
@@ -144,7 +144,8 @@ public class ItemServiceTest {
         PageRequest pageRequest = PageRequest.of(0, PAGE_SIZE);
 
         //when
-        List<ItemsResponse> items = itemService.getItems(0, searchText, pageRequest);
+//        List<ItemsResponse> items = itemService.getItems(0, searchText, pageRequest);
+        List<ItemsResponse> items = itemService.getItems(null, 1, searchText, pageRequest);
 
         //then
         assertThat(items.size()).isEqualTo(1);
@@ -161,7 +162,8 @@ public class ItemServiceTest {
         PageRequest pageRequest = PageRequest.of(0, PAGE_SIZE);
 
         //when
-        List<ItemsResponse> items = itemService.getItems(0, searchText, pageRequest);
+//        List<ItemsResponse> items = itemService.getItems(0, searchText, pageRequest);
+        List<ItemsResponse> items = itemService.getItems(null, 1, searchText, pageRequest);
 
         //then
         assertThat(items.size()).isEqualTo(1);
@@ -180,7 +182,8 @@ public class ItemServiceTest {
         PageRequest pageRequest = PageRequest.of(0, PAGE_SIZE);
 
         //when
-        List<ItemsResponse> items = itemService.getItems(0, searchText, pageRequest);
+//        List<ItemsResponse> items = itemService.getItems(0, searchText, pageRequest);
+        List<ItemsResponse> items = itemService.getItems(null, 1, searchText, pageRequest);
 
         //then
         assertThat(items.size()).isEqualTo(5);
@@ -197,7 +200,8 @@ public class ItemServiceTest {
         PageRequest pageRequest = PageRequest.of(0, PAGE_SIZE);
 
         //when
-        List<ItemsResponse> items = itemService.getItems(0, searchText, pageRequest);
+//        List<ItemsResponse> items = itemService.getItems(0, searchText, pageRequest);
+        List<ItemsResponse> items = itemService.getItems(null, 2, searchText, pageRequest);
 
         //then
         assertThat(items).isSortedAccordingTo(

--- a/src/test/java/site/bidderown/server/bounded_context/item/service/ItemServiceTest.java
+++ b/src/test/java/site/bidderown/server/bounded_context/item/service/ItemServiceTest.java
@@ -126,7 +126,6 @@ public class ItemServiceTest {
         PageRequest pageRequest = PageRequest.of(0, PAGE_SIZE);
 
         //when
-//        List<ItemsResponse> items = itemService.getItems(sortCode, searchText, pageRequest);
         List<ItemsResponse> items = itemService.getItems(null, sortCode, searchText, pageRequest);
 
         //then
@@ -144,7 +143,6 @@ public class ItemServiceTest {
         PageRequest pageRequest = PageRequest.of(0, PAGE_SIZE);
 
         //when
-//        List<ItemsResponse> items = itemService.getItems(0, searchText, pageRequest);
         List<ItemsResponse> items = itemService.getItems(null, 1, searchText, pageRequest);
 
         //then
@@ -162,7 +160,6 @@ public class ItemServiceTest {
         PageRequest pageRequest = PageRequest.of(0, PAGE_SIZE);
 
         //when
-//        List<ItemsResponse> items = itemService.getItems(0, searchText, pageRequest);
         List<ItemsResponse> items = itemService.getItems(null, 1, searchText, pageRequest);
 
         //then
@@ -182,7 +179,6 @@ public class ItemServiceTest {
         PageRequest pageRequest = PageRequest.of(0, PAGE_SIZE);
 
         //when
-//        List<ItemsResponse> items = itemService.getItems(0, searchText, pageRequest);
         List<ItemsResponse> items = itemService.getItems(null, 1, searchText, pageRequest);
 
         //then
@@ -200,7 +196,6 @@ public class ItemServiceTest {
         PageRequest pageRequest = PageRequest.of(0, PAGE_SIZE);
 
         //when
-//        List<ItemsResponse> items = itemService.getItems(0, searchText, pageRequest);
         List<ItemsResponse> items = itemService.getItems(null, 2, searchText, pageRequest);
 
         //then


### PR DESCRIPTION
#197 

## 쿼리 튜닝 결과
- MTT(API 당 처리하는 시간) 
1. 기존: 222.1 
2. 쿼리 튜닝 169.8 (썸네일 이미지 이름 가져오는 쿼리 개선)
3. No offset 적용 53.1

## ItemController

1. `/api/v1/item/list`
    - 최신순 정렬 시 no offset 적용
    - 인기순, 경매종료순은 기존처럼 offset, limit

4. `/api/v1/item/list-jpa`
    - jpa 사용
    - 팀원분들도 테스트 해보실 분 있으실까봐 남겨뒀습니다. main으로 머지할 때 삭제하면 될 거 같습니다!

5. `/api/v1/item/list-origin`
    - 기존 방식
    - 마찬가지로 main 머지할 때 삭제해도 될 거 같습니다.

## Vue
no offset 적용을 하였기 때문에 살짝 바뀌었습니다.

## Item 컬럼 추가 entity
- COMMENT_COUNT와  BID_COUNT, THUMBNAIL_IMAGE_FILE_NAME 컬럼을 추가하였습니다.
- 댓글, 입찰 시 업데이트해야 될 컬럼이 늘어나지만 COUNT 집계 쿼리를 줄여서 성능 개선을 하였습니다.(COUNT 쿼리 시 전체 조회 발생)
- 이 컬럼으로 동시성 처리까지 해볼 수 있을 거 같습니다.