### PR TITLE
[#233] 로그인 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ repositories {
 }
 
 dependencies {
+	implementation group: 'org.thymeleaf.extras', name: 'thymeleaf-extras-springsecurity5', version: '3.0.4.RELEASE'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/site/bidderown/server/base/exception/custom_exception/ForbiddenException.java
+++ b/src/main/java/site/bidderown/server/base/exception/custom_exception/ForbiddenException.java
@@ -6,7 +6,7 @@ import site.bidderown.server.base.exception.CustomException;
 import site.bidderown.server.base.exception.ErrorCode;
 
 public class ForbiddenException extends CustomException {
-    private static final ErrorCode errorCode = ErrorCode.NOT_FOUND;
+    private static final ErrorCode errorCode = ErrorCode.FORBIDDEN;
 
     public ForbiddenException(String message) {
         super(errorCode, message);

--- a/src/main/java/site/bidderown/server/bounded_context/bid/controller/BidApiController.java
+++ b/src/main/java/site/bidderown/server/bounded_context/bid/controller/BidApiController.java
@@ -29,6 +29,8 @@ public class BidApiController {
 
     @PostMapping("/api/v1/bid")
     public Long registerBid(@RequestBody BidRequest bidRequest, @AuthenticationPrincipal User user){
+        if(user == null)
+            throw new ForbiddenException("로그인 후 접근이 가능합니다.");
         return bidService.handleBid(bidRequest, user.getUsername());
     }
 

--- a/src/main/java/site/bidderown/server/bounded_context/bid/controller/BidController.java
+++ b/src/main/java/site/bidderown/server/bounded_context/bid/controller/BidController.java
@@ -22,7 +22,6 @@ public class BidController {
     private final BidService bidService;
 
     @GetMapping("/bid/list")
-    @PreAuthorize("isAuthenticated()")
     public String bidList(@RequestParam Long itemId, Model model, @AuthenticationPrincipal User user){
         model.addAttribute("itemId", itemId);
         return "usr/bid/list";

--- a/src/main/java/site/bidderown/server/bounded_context/chat_room/controller/ChatRoomApiController.java
+++ b/src/main/java/site/bidderown/server/bounded_context/chat_room/controller/ChatRoomApiController.java
@@ -14,25 +14,25 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/chat-room")
 public class ChatRoomApiController {
 
     private final ChatRoomService chatRoomService;
 
     @PreAuthorize("isAuthenticated()")
-    @GetMapping("/chat-room/list")
+    @GetMapping("/list")
     public List<ChatRoomResponse> findChatRoomList(@AuthenticationPrincipal User user) {
         return chatRoomService.getChatRooms(user.getUsername());
     }
 
-    @GetMapping("/chat-detail/{chatRoomId}")
-    public ChatRoomDetail joinChat(@AuthenticationPrincipal User user, @PathVariable Long chatRoomId){
+    @GetMapping("/detail/{chatRoomId}")
+    public ChatRoomDetail getChatRoomDetail(@AuthenticationPrincipal User user, @PathVariable Long chatRoomId){
         return chatRoomService.getChatRoomDetail(chatRoomId, user.getUsername());
     }
 
-    @PostMapping("/chat-room")
+    @PostMapping
     @PreAuthorize("isAuthenticated()")
-    public String handleChatRoom(@RequestBody ChatRoomRequest chatRoomRequest){
-        return "/chat/list?id=" + chatRoomService.handleChatRoom(chatRoomRequest);
+    public Long handleChatRoom(@RequestBody ChatRoomRequest chatRoomRequest){
+        return chatRoomService.handleChatRoom(chatRoomRequest);
     }
 }

--- a/src/main/java/site/bidderown/server/bounded_context/chat_room/controller/ChatRoomController.java
+++ b/src/main/java/site/bidderown/server/bounded_context/chat_room/controller/ChatRoomController.java
@@ -20,19 +20,20 @@ public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
 
-    @GetMapping("/chat/list")
+    @GetMapping("/chat-room/list")
     @PreAuthorize("isAuthenticated()")
     public String showChatRoomList (
             Model model,
-            @RequestParam(value = "id", required = false) Long chatRoomId
+            @RequestParam(value = "itemId", required = false) Long itemId,
+            @RequestParam(value = "buyerName", required = false) String buyerName
     ) {
         /**
          *  채팅방 리스트 페이지로 이동
          *  model에 담겨있는 채팅방에 자동
          */
-        if (chatRoomId != null)
-            model.addAttribute("chatRoomId", chatRoomId);
+        model.addAttribute("itemId", itemId);
+        model.addAttribute("buyerName", buyerName);
 
-        return "usr/chat/list";
+        return "usr/chatroom/list";
     }
 }

--- a/src/main/java/site/bidderown/server/bounded_context/chat_room/service/ChatRoomService.java
+++ b/src/main/java/site/bidderown/server/bounded_context/chat_room/service/ChatRoomService.java
@@ -45,6 +45,9 @@ public class ChatRoomService {
 
     @Transactional
     public Long handleChatRoom(ChatRoomRequest chatRoomRequest) {
+        if(chatRoomRequest.getBuyerName() == null && chatRoomRequest.getItemId() == null)
+            return -1L;
+
         Item item = itemService.getItem(chatRoomRequest.getItemId());
         Member buyer = memberService.getMember(chatRoomRequest.getBuyerName());
         Member seller = item.getMember();

--- a/src/main/java/site/bidderown/server/bounded_context/comment/controller/CommentApiController.java
+++ b/src/main/java/site/bidderown/server/bounded_context/comment/controller/CommentApiController.java
@@ -5,6 +5,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
+import site.bidderown.server.base.exception.custom_exception.ForbiddenException;
 import site.bidderown.server.bounded_context.comment.controller.dto.CommentDetailResponse;
 import site.bidderown.server.bounded_context.comment.controller.dto.CommentRequest;
 import site.bidderown.server.bounded_context.comment.controller.dto.CommentResponse;
@@ -20,12 +21,13 @@ public class CommentApiController {
     private final CommentService commentService;
 
     @PostMapping("/{itemId}/comment")
-    @PreAuthorize("isAuthenticated()")
     public CommentResponse createComment(
             @RequestBody CommentRequest request,
             @PathVariable Long itemId,
             @AuthenticationPrincipal User user
     ) {
+        if(user == null)
+            throw new ForbiddenException("로그인 후 접근이 가능합니다.");
         return CommentResponse.of(commentService.create(request, itemId, user.getUsername()));
     }
 

--- a/src/main/java/site/bidderown/server/bounded_context/member/controller/MemberController.java
+++ b/src/main/java/site/bidderown/server/bounded_context/member/controller/MemberController.java
@@ -11,6 +11,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import site.bidderown.server.base.exception.custom_exception.ForbiddenException;
 import site.bidderown.server.bounded_context.item.controller.dto.ItemSimpleResponse;
 import site.bidderown.server.bounded_context.item.service.ItemService;
 import site.bidderown.server.bounded_context.member.controller.dto.MemberDetail;
@@ -54,6 +55,8 @@ public class MemberController {
     @GetMapping("/api/v1/socket-id")
     @ResponseBody
     public String getSocketId(@AuthenticationPrincipal User user) {
+        if(user == null)
+            throw new ForbiddenException("로그인 후 접근이 가능합니다.");
         return socketPath + memberService.getMember(user.getUsername()).getId();
     }
 }

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -1,4 +1,4 @@
-<div>
+<div xmlns:sec="http://www.w3.org/1999/xhtml">
     <div th:replace="import::head"></div>
     <div class="flex justify-center w-full h-[70px] bg-white" id="header_app">
         <div class="flex w-[1100px] h-[70px] justify-between items-center pr-5 pl-5 bg-white">
@@ -15,14 +15,17 @@
             </div>
 
             <div class="flex">
-                <a href="/chat-room/list" onclick="readChat()" class="mr-2">
+                <a sec:authorize="isAuthenticated()" href="/chat-room/list" onclick="readChat()" class="mr-2">
                     <img id="chat-icon" src="https://kr.object.ncloudstorage.com/s3bucket/chat.png" class="w-[38px] h-[38px]"/>
                 </a>
-                <a href="/notifications" onclick="readNotification()" class="mr-2">
+                <a sec:authorize="isAuthenticated()" href="/notifications" onclick="readNotification()" class="mr-2">
                     <img id="notification-icon" src="https://kr.object.ncloudstorage.com/s3bucket/notification.png" class="w-[38px] h-[38px]"/>
                 </a>
-                <a href="/my-page">
+                <a sec:authorize="isAuthenticated()" href="/my-page">
                     <img src="https://kr.object.ncloudstorage.com/s3bucket/person2.png" class="w-[38px] h-[38px]"/>
+                </a>
+                <a sec:authorize="!isAuthenticated()" href="/login">
+                    <img src="https://kr.object.ncloudstorage.com/s3bucket/login.png" class="w-[38px] h-[38px]"/>
                 </a>
             </div>
         </div>

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -15,7 +15,7 @@
             </div>
 
             <div class="flex">
-                <a href="/chat/list" onclick="readChat()" class="mr-2">
+                <a href="/chat-room/list" onclick="readChat()" class="mr-2">
                     <img id="chat-icon" src="https://kr.object.ncloudstorage.com/s3bucket/chat.png" class="w-[38px] h-[38px]"/>
                 </a>
                 <a href="/notifications" onclick="readNotification()" class="mr-2">
@@ -80,7 +80,7 @@
                                     localStorage.setItem('notificationStatus', '1');
                                     $('#notification-icon').attr('src', 'https://kr.object.ncloudstorage.com/s3bucket/notification_noti.png');
                                 } else {
-                                    if (window.location.href.includes("/chat/list")) return;
+                                    if (window.location.href.includes("/chat-room/list")) return;
                                     localStorage.setItem('chatStatus', '1');
                                     $('#chat-icon').attr('src', 'https://kr.object.ncloudstorage.com/s3bucket/chat_noti.png');
                                 }

--- a/src/main/resources/templates/usr/bid/list.html
+++ b/src/main/resources/templates/usr/bid/list.html
@@ -103,7 +103,7 @@
                             <div v-if="username === sellerName && (itemStatus === 'BIDDING' || itemStatus === 'BID_END')"
                                  class="items-center  mr-2">
                                 <a class="border-solid border-[1px] px-2 py-1 border-indigo-400 bg-indigo-400  hover:bg-indigo-600 rounded-md text-white"
-                                   v-on:click="handleChat(bid.bidderName)">채팅하기
+                                   v-on:click="clickChatButton(bid.bidderName)">채팅하기
                                 </a>
                             </div>
                         </button>
@@ -202,13 +202,8 @@
                     this.updateData();
                 }).catch();
             },
-            handleChat(bidderName) {
-                axios.post('/api/v1/chat-room', {
-                    buyerName: bidderName,
-                    itemId: this.itemId
-                }).then(response => {
-                    window.location.href = window.location.protocol + "//" + window.location.host + response.data;
-                }).catch(error => console.log(error));
+            clickChatButton(bidderName) {
+                window.location.href  = window.location.protocol + "//" + window.location.host + "/chat-room/list?itemId=" + this.itemId + "&buyerName=" + bidderName;
             },
             soldOut() {
                 axios.put('/api/v1/item/sold-out', {

--- a/src/main/resources/templates/usr/chatroom/list.html
+++ b/src/main/resources/templates/usr/chatroom/list.html
@@ -97,7 +97,8 @@
         <div class="border border-inherit"></div>
     </div>
     <div class="border border-inherit"></div>
-    <input type="hidden" id="chatRoomId" th:value="${ chatRoomId }">
+    <input type="hidden" id="itemId" th:value="${ itemId }">
+    <input type="hidden" id="buyerName" th:value="${ buyerName }">
 </div>
 </body>
 
@@ -120,29 +121,38 @@
             itemId: -1
         },
         created() {
-            const chatRoomId = document.getElementById('chatRoomId').value;
+            const itemId = document.getElementById('itemId').value;
+            const buyerName = document.getElementById('buyerName').value;
             this.username = localStorage.getItem('username');
-
-            axios.get('/api/v1/chat-room/list', {
-                auth: {
-                    username: this.username,
-                    password: ''
-                }
+            /**
+             * 채팅방 리스트 페이지에 오면 기본적으로 handleChat메서드를 통해 참여할 채팅방의 아이디를 넘겨받습니다.
+             * 인자값 없이 넘어왔을 때는 -1을 넘겨받습니다.
+             * 비동기 처리의 순서를 보장하기 위해 채팅방 생성 or 조회 -> 채팅방 목록 조회 -> 전역 데이터에 체팅방 추가
+             */
+            axios.post('/api/v1/chat-room', {
+                buyerName: buyerName,
+                itemId: itemId
             })
                 .then(response => {
-                    const chatRooms = response.data;
-                    chatRooms.forEach(chatRoom => {
+                    this.chatRoomId = response.data;
+                    return axios.get('/api/v1/chat-room/list', {
+                    });
+                })
+                .then(response => {
+                    response.data.forEach(chatRoom => {
                         this.chatRooms.push({
                             chatRoomId: chatRoom.chatRoomId,
                             toUserId: chatRoom.toUserId,
                             toUserName: chatRoom.toUserName,
-                        })
+                        });
                     });
-
-                    if (chatRoomId !== '') {
-                        this.connectChatRoom(parseInt(chatRoomId))
+                    console.log("chatRoomId: ", this.chatRoomId);
+                    if (this.chatRoomId !== -1) {
+                        this.connectChatRoom(parseInt(this.chatRoomId));
                     }
-                });
+                })
+                .catch(error => console.log(error));
+
         },
 
         methods: {
@@ -200,12 +210,9 @@
                 });
             },
             updateChatRoomDetail(chatRoomId) {
-                axios.get('/api/v1/chat-detail/' + chatRoomId, {
-                    auth: {
-                        username: this.username,
-                        password: ''
-                    }
+                axios.get('/api/v1/chat-room/detail/' + chatRoomId, {
                 }).then(response => {
+                    console.log(response);
                     const data = response.data;
                     this.toUserId = data.toUserId;
                     this.itemPrice = data.price;

--- a/src/main/resources/templates/usr/item/detail.html
+++ b/src/main/resources/templates/usr/item/detail.html
@@ -64,8 +64,7 @@
                     <a class="border-solid border-[1px] px-9 py-1 h-[35px] border-indigo-400 bg-indigo-400  hover:bg-indigo-600 rounded-md text-white"
                        :href="'/bid/list?itemId=' + itemId">
                         <span v-if="isMe()">입찰내역</span>
-                        <span v-else-if="item.itemStatus === 'BIDDING'">입찰하기</span>
-                        <span v-else-if="item.itemStatus === 'BID_END' || item.itemStatus === 'SOLDOUT'">입찰목록</span>
+                        <span v-else >입찰목록</span>
                     </a>
                 </div>
             </div>
@@ -153,7 +152,7 @@
                 }).then(response => {
                     this.comments.push(response.data);
                     this.commentMessage = ''
-                })
+                }).catch(error => window.location.href = window.location.protocol + "//" + window.location.host + "/login");
 
                 this.commentCount++;
 

--- a/src/main/resources/templates/usr/item/detail.html
+++ b/src/main/resources/templates/usr/item/detail.html
@@ -57,7 +57,7 @@
                     </div>
                     <div v-else class="flex h-[35px]">
                         <button class="border-solid border-[1px]  h-[35px] border-gray-400 px-9 py-1 rounded-md mr-2 hover:bg-gray-100"
-                                v-on:click="handleChat()">
+                                v-on:click="clickChatButton()">
                             채팅하기
                         </button>
                     </div>
@@ -167,13 +167,8 @@
                 })
 
             },
-            handleChat() {
-                axios.post('/api/v1/chat-room', {
-                    buyerName: this.username,
-                    itemId: this.itemId
-                }).then(response => {
-                    window.location.href = window.location.protocol + "//" + window.location.host + response.data;
-                }).catch(error => console.log(error));
+            clickChatButton() {
+                window.location.href = window.location.protocol + "//" + window.location.host + "/chat-room/list?itemId=" + this.itemId + "&buyerName=" + this.username;
             },
             isMe() {
                 return this.item.memberName === this.username;


### PR DESCRIPTION
- 로그인 버튼 추가
    - 일단 로그인 안했을 때는 로그인 아이콘만 로그인 했을 때는 나머지 아이콘 보이게 해놨습니다.
    - 이미지는 아무거나 주워다 쓴거라 괜찮은거 있으시면 공유해주시면 감사하겠습니다.
- 로그인 페이지로 이동 안됨(소켓, 댓글, 입찰)
    -  댓글이나 입찰같은 경우에는 페이지 보다는 api의 개념이고 principalAuthentication을 이용해서 예외처리 했습니다.
    - 응답 메시지로 구분해서 분기처리 해놨고 만약 다른 예외가 터질 수 있는 상황이면 추가하면 될 것 같습니다. 지금 당장은 메세지로 구분했는데 응답 코드를 정하면 좀 더 깔끔할 것 같아요
- 채팅하기
    - 위에처럼 처리할까 하다가 RestController에서 url을 반환하는게 맞나 싶어서 일단 handleChatRoom으로 들어가는 bidList페이지와 itemDetails의 채팅하기 버튼은 chatList페이지로 몰아서 처리했습니다. 예외처리도 추가할까 하다가 애초에 컨트롤러 단에서 막을 수 있어 일단 미뤘습니다..ㅎㅎ
