### PR TITLE
[#307] 예외처리 스타일 통합 작업

### DIFF
--- a/src/main/java/site/bidderown/server/base/exception/CustomException.java
+++ b/src/main/java/site/bidderown/server/base/exception/CustomException.java
@@ -7,20 +7,15 @@ public abstract class CustomException extends RuntimeException{
     private final ErrorCode errorCode;
     private String logMessage;
 
-    protected CustomException(ErrorCode errorCode, String message, String logMessage){
+    protected CustomException(ErrorCode errorCode, String message, String id){
         super(message);
         this.errorCode = errorCode;
-        this.logMessage = message + " (" + logMessage + ")";
+        this.logMessage = message + " (" + id + ")";
     }
 
     protected CustomException(ErrorCode errorCode, String message){
         super(message);
         this.errorCode = errorCode;
-    }
-
-    protected CustomException(ErrorCode errorCode, String message, Long id){
-        super(message);
-        this.errorCode = errorCode;
-        this.logMessage = message + " (" + id + ")";
+        this.logMessage = message;
     }
 }

--- a/src/main/java/site/bidderown/server/base/exception/GlobalExceptionHandler.java
+++ b/src/main/java/site/bidderown/server/base/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package site.bidderown.server.base.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -42,6 +43,13 @@ public class GlobalExceptionHandler {
                 .forEach(c -> errors.put(((FieldError) c).getField(), c.getDefaultMessage()));
         log.warn(ex.getMessage());
         return ResponseEntity.badRequest().body(errors);
+    }
+
+    @ExceptionHandler(RedisConnectionFailureException.class)
+    public ResponseEntity<ErrorResponse> handleRedisConnectionFailureExceptions(RedisConnectionFailureException e){
+        ErrorResponse errorResponse = new ErrorResponse("서버 장애로 요청이 실패했습니다. 잠시 후 다시 시도해주세요!");
+        log.error(e.getMessage());
+        return ResponseEntity.status(500).body(errorResponse);
     }
 
 }

--- a/src/main/java/site/bidderown/server/base/exception/custom_exception/BidEndItemException.java
+++ b/src/main/java/site/bidderown/server/base/exception/custom_exception/BidEndItemException.java
@@ -6,7 +6,7 @@ import site.bidderown.server.base.exception.ErrorCode;
 public class BidEndItemException extends CustomException {
     private static final ErrorCode errorCode = ErrorCode.BID_END;
 
-    public BidEndItemException(Long itemId){
+    public BidEndItemException(String itemId){
         super(errorCode,  "입찰이 종료된 아이템입니다.", itemId);
     }
 }

--- a/src/main/java/site/bidderown/server/base/exception/custom_exception/NotFoundException.java
+++ b/src/main/java/site/bidderown/server/base/exception/custom_exception/NotFoundException.java
@@ -12,7 +12,7 @@ import java.io.Serializable;
 public class NotFoundException extends CustomException {
     private static final ErrorCode errorCode = ErrorCode.NOT_FOUND;
 
-    public NotFoundException(String message, String logMessage){
-        super(errorCode,  message, logMessage);
+    public NotFoundException(String message, String id){
+        super(errorCode,  message, id);
     }
 }

--- a/src/main/java/site/bidderown/server/base/exception/custom_exception/SoldOutItemException.java
+++ b/src/main/java/site/bidderown/server/base/exception/custom_exception/SoldOutItemException.java
@@ -6,7 +6,7 @@ import site.bidderown.server.base.exception.ErrorCode;
 public class SoldOutItemException extends CustomException {
     private static final ErrorCode errorCode = ErrorCode.SOLDOUT;
 
-    public SoldOutItemException(String message, String logMessage){
-        super(errorCode,  message, logMessage);
+    public SoldOutItemException(String message, String id){
+        super(errorCode,  message, id);
     }
 }

--- a/src/main/java/site/bidderown/server/base/exception/custom_exception/WrongBidPriceException.java
+++ b/src/main/java/site/bidderown/server/base/exception/custom_exception/WrongBidPriceException.java
@@ -6,7 +6,7 @@ import site.bidderown.server.base.exception.ErrorCode;
 public class WrongBidPriceException extends CustomException {
     private static final ErrorCode errorCode = ErrorCode.LOWER_BID_PRICE;
 
-    public WrongBidPriceException(Long id){
-        super(errorCode, "잘못된 입찰가 제시", "Bid with a wrong price. item id: " + id);
+    public WrongBidPriceException(String id){
+        super(errorCode, "잘못된 입찰가 제시", id);
     }
 }

--- a/src/main/java/site/bidderown/server/boundedcontext/bid/service/BidService.java
+++ b/src/main/java/site/bidderown/server/boundedcontext/bid/service/BidService.java
@@ -50,14 +50,14 @@ public class BidService {
         Item item = itemService.getItem(bidRequest.getItemId());
 
         if (!isBidding(item)) {
-            throw new BidEndItemException(item.getId());
+            throw new BidEndItemException(item.getId() + "");
         }
 
         Integer maxPrice = bidRepository.findMaxPrice(item);
         int bidPrice = bidRequest.getItemPrice();
 
         if (!availableBid(item, maxPrice, bidPrice)) {
-            throw new WrongBidPriceException(item.getId());
+            throw new WrongBidPriceException(item.getId() + "");
         }
 
         Member bidder = memberService.getMember(username);


### PR DESCRIPTION
**기존 예외 처리 방식이 너무 혼잡스러워 정리를 진행했습니다.** 

- logMessage에 id값을 표기하는 경우에 Long타입으로 id를 받는 것이 좋겠지만 name을 처리해야 하는 경우가 있어 String타입으로 받는 것으로 통합했습니다.
- ForbiddenException같은 경우에는 별도의 아이디나 이름을 받지 않으므로 기본 메시지로 처리하게 끔 통합했습니다.
- logMessage를 별도로 받는 방법은 통일성에 어긋난다 판단해서 일단 제거했습니다. 
- 일단 수정은 진행했는데 가장 좋은 방법은 아닌 것 같네요 추후에 더 좋은 방법 있으면 리팩토링 진행하면 좋을 것 같습니다. 

```
    protected CustomException(ErrorCode errorCode, String message, String id){
        super(message);
        this.errorCode = errorCode;
        this.logMessage = message + " (" + id + ")";
    }

    protected CustomException(ErrorCode errorCode, String message){
        super(message);
        this.errorCode = errorCode;
        this.logMessage = message;
    }
```
추가로 RedisConnecitonFailureException도 처리했습니다.